### PR TITLE
[ark-ui-kit-renderer] feat: update joystick with clamp magnitude and set size, centerPoint for button

### DIFF
--- a/ArkKit/ViewController.swift
+++ b/ArkKit/ViewController.swift
@@ -8,10 +8,10 @@ class ViewController: UIViewController {
         self.view.backgroundColor = .white
         self.view.isUserInteractionEnabled = true
 
-//        let joystick = UIKitJoystick(center: CGPoint(x: midX, y: midY), radius: 50)
-//        joystick.render(into: self.view)
-        let button = UIKitButton(width: 100, height: 100, center: CGPoint(x: midX, y: midY))
-        button.backgroundColor = .red
-        button.render(into: self.view)
+        let joystick = UIKitJoystick(center: CGPoint(x: midX, y: midY), radius: 50)
+        joystick.render(into: self.view)
+//        let button = UIKitButton(width: 100, height: 100, center: CGPoint(x: midX, y: midY))
+//        button.backgroundColor = .red
+//        button.render(into: self.view)
     }
 }

--- a/ArkKit/ViewController.swift
+++ b/ArkKit/ViewController.swift
@@ -8,10 +8,10 @@ class ViewController: UIViewController {
         self.view.backgroundColor = .white
         self.view.isUserInteractionEnabled = true
 
-        let joystick = UIKitJoystick(center: CGPoint(x: midX, y: midY), radius: 50)
-        joystick.render(into: self.view)
-    }
-    @objc func handleTap(_ gesture: UITapGestureRecognizer) {
-        print("tapped joystick")
+//        let joystick = UIKitJoystick(center: CGPoint(x: midX, y: midY), radius: 50)
+//        joystick.render(into: self.view)
+        let button = UIKitButton(width: 100, height: 100, center: CGPoint(x: midX, y: midY))
+        button.backgroundColor = .red
+        button.render(into: self.view)
     }
 }

--- a/ArkKit/ark-ui-kit-renderer/view-components/input/UIKitButton.swift
+++ b/ArkKit/ark-ui-kit-renderer/view-components/input/UIKitButton.swift
@@ -1,31 +1,29 @@
-//
-//  UIKitButton.swift
-//  ArkKit
-//
-//  Created by En Rong on 16/3/24.
-//
-
 import UIKit
 
-class UIKitButton: UIView, UIKitRenderable, TapRenderable {
+final class UIKitButton: UIButton, UIKitRenderable, TapRenderable {
     var onTapDelegate: TapDelegate?
 
-    init() {
-        let frame = CGRect(x: 0, y: 0, width: 100, height: 50)
+    init(width: Double, height: Double, center: CGPoint) {
+        let frame = CGRect(x: center.x - width / 2, y: center.y - height / 2,
+                           width: width, height: height)
         super.init(frame: frame)
-
-        // TODO: Update UIButton styling
-        let button = UIButton()
-        button.addTarget(self, action: #selector(handleTap), for: .touchUpInside)
+        setUpTap()
     }
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
     }
 
-    @objc func handleTap() {
+    @objc func handleTap(_ gesture: UITapGestureRecognizer) {
         if let unwrappedOnTapDelegate = onTapDelegate {
             unwrappedOnTapDelegate()
         }
     }
+    private func setUpTap() {
+        let tap = UITapGestureRecognizer(target: self, action: #selector(handleTap(_:)))
+        self.addGestureRecognizer(tap)
+    }
+    // TODO: implement button styling as required below
+    // currently we inherit `UIButton` so all default styling of `UIButton` is automatically
+    // exposed from `UIKitButton`
 }

--- a/ArkKit/ark-ui-kit-renderer/view-components/input/UIKitJoystick.swift
+++ b/ArkKit/ark-ui-kit-renderer/view-components/input/UIKitJoystick.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class UIKitJoystick: UIView, UIKitRenderable, PanRenderable {
+final class UIKitJoystick: UIView, UIKitRenderable, PanRenderable {
     var onPanStartDelegate: PanDelegate?
     var onPanChangeDelegate: PanDelegate?
     var onPanEndDelegate: PanDelegate?


### PR DESCRIPTION
### Requirements
- [x] Clamp Pannable magnitude for Joystick (so the inner circle joystick does not go out of bounds)
- [x] Allow `UIKitButton` to set size and center anchor

### Notes
1. The angle calculated for pan is the clockwise angle from the user's perspective. Upwards is 0 degrees, right is 90 degrees, down is 180 degrees, left is 270 degrees. The angle calculated is in radians.