### PR TITLE
[ark-rules] feat: implement blueprint, rules, modify event and ecs context

### DIFF
--- a/ArkKit.xcodeproj/project.pbxproj
+++ b/ArkKit.xcodeproj/project.pbxproj
@@ -18,6 +18,13 @@
 		02C394F72BA4428A0075F1CA /* UIKitJoystick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C394F62BA4428A0075F1CA /* UIKitJoystick.swift */; };
 		02C394F92BA443830075F1CA /* TapRenderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C394F82BA443830075F1CA /* TapRenderable.swift */; };
 		02C394FB2BA444360075F1CA /* PanRenderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C394FA2BA444360075F1CA /* PanRenderable.swift */; };
+		02C395012BA5A2BE0075F1CA /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C395002BA5A2BE0075F1CA /* Action.swift */; };
+		02C395032BA5B95B0075F1CA /* Rule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C395022BA5B95B0075F1CA /* Rule.swift */; };
+		02C395062BA5E2E00075F1CA /* Once.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C395052BA5E2E00075F1CA /* Once.swift */; };
+		02C395082BA5E2F10075F1CA /* Forever.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C395072BA5E2F10075F1CA /* Forever.swift */; };
+		02C3950B2BA5F8030075F1CA /* ArkECSContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C3950A2BA5F8030075F1CA /* ArkECSContext.swift */; };
+		02C3950D2BA5FE5C0075F1CA /* ArkBlueprint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C3950C2BA5FE5C0075F1CA /* ArkBlueprint.swift */; };
+		02C3950F2BA611B80075F1CA /* ArkEventContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C3950E2BA611B80075F1CA /* ArkEventContext.swift */; };
 		02E0E8EE2BA280BD0043E2BA /* UIKitShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E0E8ED2BA280BD0043E2BA /* UIKitShape.swift */; };
 		02E0E8F02BA280DB0043E2BA /* UIKitRenderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E0E8EF2BA280DB0043E2BA /* UIKitRenderable.swift */; };
 		02E0E8F22BA282C20043E2BA /* UIKitCircle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E0E8F12BA282C20043E2BA /* UIKitCircle.swift */; };
@@ -81,6 +88,13 @@
 		02C394F62BA4428A0075F1CA /* UIKitJoystick.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitJoystick.swift; sourceTree = "<group>"; };
 		02C394F82BA443830075F1CA /* TapRenderable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapRenderable.swift; sourceTree = "<group>"; };
 		02C394FA2BA444360075F1CA /* PanRenderable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanRenderable.swift; sourceTree = "<group>"; };
+		02C395002BA5A2BE0075F1CA /* Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Action.swift; sourceTree = "<group>"; };
+		02C395022BA5B95B0075F1CA /* Rule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Rule.swift; sourceTree = "<group>"; };
+		02C395052BA5E2E00075F1CA /* Once.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Once.swift; sourceTree = "<group>"; };
+		02C395072BA5E2F10075F1CA /* Forever.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Forever.swift; sourceTree = "<group>"; };
+		02C3950A2BA5F8030075F1CA /* ArkECSContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArkECSContext.swift; sourceTree = "<group>"; };
+		02C3950C2BA5FE5C0075F1CA /* ArkBlueprint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArkBlueprint.swift; sourceTree = "<group>"; };
+		02C3950E2BA611B80075F1CA /* ArkEventContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArkEventContext.swift; sourceTree = "<group>"; };
 		02E0E8ED2BA280BD0043E2BA /* UIKitShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitShape.swift; sourceTree = "<group>"; };
 		02E0E8EF2BA280DB0043E2BA /* UIKitRenderable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitRenderable.swift; sourceTree = "<group>"; };
 		02E0E8F12BA282C20043E2BA /* UIKitCircle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitCircle.swift; sourceTree = "<group>"; };
@@ -196,6 +210,33 @@
 			path = input;
 			sourceTree = "<group>";
 		};
+		02C394FD2BA5A09D0075F1CA /* ark-rules-kit */ = {
+			isa = PBXGroup;
+			children = (
+				02C395092BA5E4DA0075F1CA /* rule */,
+				02C395042BA5E2C30075F1CA /* action */,
+			);
+			path = "ark-rules-kit";
+			sourceTree = "<group>";
+		};
+		02C395042BA5E2C30075F1CA /* action */ = {
+			isa = PBXGroup;
+			children = (
+				02C395002BA5A2BE0075F1CA /* Action.swift */,
+				02C395052BA5E2E00075F1CA /* Once.swift */,
+				02C395072BA5E2F10075F1CA /* Forever.swift */,
+			);
+			path = action;
+			sourceTree = "<group>";
+		};
+		02C395092BA5E4DA0075F1CA /* rule */ = {
+			isa = PBXGroup;
+			children = (
+				02C395022BA5B95B0075F1CA /* Rule.swift */,
+			);
+			path = rule;
+			sourceTree = "<group>";
+		};
 		02E0E8DE2B9F57170043E2BA /* ark-ui-kit-renderer */ = {
 			isa = PBXGroup;
 			children = (
@@ -295,6 +336,7 @@
 				AD6E03642BA1949000974EBF /* ArkEvent.swift */,
 				AD6E03672BA1A61200974EBF /* ArkEventManager.swift */,
 				AD6E036C2BA1AB2D00974EBF /* DemoArkEvent.swift */,
+				02C3950E2BA611B80075F1CA /* ArkEventContext.swift */,
 			);
 			path = "ark-event-kit";
 			sourceTree = "<group>";
@@ -340,6 +382,8 @@
 			isa = PBXGroup;
 			children = (
 				02C394E22BA407420075F1CA /* Ark.swift */,
+				02C3950C2BA5FE5C0075F1CA /* ArkBlueprint.swift */,
+				02C394FD2BA5A09D0075F1CA /* ark-rules-kit */,
 				02C394DA2BA401F00075F1CA /* ark-render-kit */,
 				02E0E8DE2B9F57170043E2BA /* ark-ui-kit-renderer */,
 				AD6E03662BA1A5EA00974EBF /* ark-event-kit */,
@@ -366,6 +410,7 @@
 		AD787A802B9C6BCE003EBBD0 /* ark-state-kit */ = {
 			isa = PBXGroup;
 			children = (
+				02C3950A2BA5F8030075F1CA /* ArkECSContext.swift */,
 				AD787A892B9C70D8003EBBD0 /* ArkState.swift */,
 				AD6E03752BA2F24800974EBF /* ArkStateEventListener.swift */,
 				AD6E035F2B9F067100974EBF /* ark-ecs-kit */,
@@ -525,8 +570,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				02C3950F2BA611B80075F1CA /* ArkEventContext.swift in Sources */,
 				02C394F72BA4428A0075F1CA /* UIKitJoystick.swift in Sources */,
 				AD787A822B9C6BD9003EBBD0 /* Entity.swift in Sources */,
+				02C395062BA5E2E00075F1CA /* Once.swift in Sources */,
 				02E0E8F62BA283940043E2BA /* UIKitPolygon.swift in Sources */,
 				8F5573C12BA42614007030C8 /* Renderable.swift in Sources */,
 				AD787A882B9C6D3A003EBBD0 /* EntityManager.swift in Sources */,
@@ -539,6 +586,8 @@
 				02E0E8F22BA282C20043E2BA /* UIKitCircle.swift in Sources */,
 				02C394E62BA41AC60075F1CA /* ArkGameModel.swift in Sources */,
 				02E0E8F42BA283180043E2BA /* UIKitRect.swift in Sources */,
+				02C395082BA5E2F10075F1CA /* Forever.swift in Sources */,
+				02C3950D2BA5FE5C0075F1CA /* ArkBlueprint.swift in Sources */,
 				02C394EC2BA41DF00075F1CA /* ArkViewController.swift in Sources */,
 				02E0E8F42BA283180043E2BA /* UIKitRect.swift in Sources */,
 				AD787A552B9C636F003EBBD0 /* ViewController.swift in Sources */,
@@ -553,6 +602,7 @@
 				02E0E8F82BA284540043E2BA /* UIKitBitmap.swift in Sources */,
 				02E0E8F02BA280DB0043E2BA /* UIKitRenderable.swift in Sources */,
 				02C394DC2BA402060075F1CA /* GameStateRenderer.swift in Sources */,
+				02C395032BA5B95B0075F1CA /* Rule.swift in Sources */,
 				945F7F852BA55ECA00933629 /* UIKitButton.swift in Sources */,
 				02E0E8F82BA284540043E2BA /* UIKitBitmap.swift in Sources */,
 				02C394DE2BA4053E0075F1CA /* CanvasRenderer.swift in Sources */,
@@ -561,11 +611,13 @@
 				02C394FB2BA444360075F1CA /* PanRenderable.swift in Sources */,
 				AD787A862B9C6C91003EBBD0 /* System.swift in Sources */,
 				8F5573C32BA4284D007030C8 /* BitmapRenderable.swift in Sources */,
+				02C395012BA5A2BE0075F1CA /* Action.swift in Sources */,
 				02C394E02BA405C10075F1CA /* Canvas.swift in Sources */,
 				AD787A842B9C6C78003EBBD0 /* Component.swift in Sources */,
 				8F5573BF2BA425E4007030C8 /* ShapeRenderable.swift in Sources */,
 				AD787A8C2B9C70FC003EBBD0 /* SystemManager.swift in Sources */,
 				02C394EF2BA420210075F1CA /* ArkGameCoordinator.swift in Sources */,
+				02C3950B2BA5F8030075F1CA /* ArkECSContext.swift in Sources */,
 				AD6E03742BA2DB4100974EBF /* PriorityQueue.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ArkKit/Ark.swift
+++ b/ArkKit/Ark.swift
@@ -1,10 +1,10 @@
 // TODO: remove dependency to UIKit
 import UIKit
 /**
- * `Ark` describes the blueprint of a game. Devs should only use `Ark` to create their games
- * by defining the rules, events, and inputs.
+ * `Ark` describes a **running instance** of the game.
  *
- * `Ark.start()`: returns the running instance of the game at a particular timeframe, `deltaTime` or `dt`.
+ * `Ark.start(blueprint)` starts the game from `deltaTime = 0` based on the
+ *  information and data in the `ArkBlueprint` provided.
  */
 class Ark {
     // TODO: remove UIKit dependency
@@ -12,8 +12,8 @@ class Ark {
     // 1. handle rendering of the game -> RenderingKit
     // 2. handle game loop updates -> LoopKit
     let rootView: UINavigationController
-    var eventContext = ArkEventManager()
-    let ecsContext = ArkECS()
+    let eventManager = ArkEventManager()
+    let ecsManager = ArkECS()
 
     init(rootView: UINavigationController) {
         self.rootView = rootView
@@ -22,19 +22,19 @@ class Ark {
     func start(blueprint: ArkBlueprint) {
         // subscribe all rules to the eventManager
         for rule in blueprint.rules {
-            eventContext.subscribe(to: rule.event) { [weak self] (event: any ArkEvent) -> Void in
+            eventManager.subscribe(to: rule.event) { [weak self] (event: any ArkEvent) -> Void in
                 guard let arkInstance = self else {
                     return
                 }
                 rule.action.execute(event,
-                                    eventContext: arkInstance.eventContext,
-                                    ecsContext: arkInstance.ecsContext)
+                                    eventContext: arkInstance.eventManager,
+                                    ecsContext: arkInstance.ecsManager)
             }
         }
         // initialise game with rootView, and eventManager
         let gameCoordinator = ArkGameCoordinator(rootView: rootView,
-                                                 eventManager: self.eventContext,
-                                                 arkECS: self.ecsContext)
+                                                 eventManager: self.eventManager,
+                                                 arkECS: self.ecsManager)
         gameCoordinator.start()
     }
 }

--- a/ArkKit/ArkBlueprint.swift
+++ b/ArkKit/ArkBlueprint.swift
@@ -1,3 +1,8 @@
+/**
+ * Devs should only use `ArkBlueprint` to defining the rules, events, and inputs.
+ *
+ * `ArkBlueprint` is effectively the blueprint struct that will be read to return an `Ark` game instance.
+ */
 struct ArkBlueprint {
     private(set) var rules: [Rule] = []
     mutating func rules<Event: ArkEvent>(on eventType: Event.Type,

--- a/ArkKit/ArkBlueprint.swift
+++ b/ArkKit/ArkBlueprint.swift
@@ -5,9 +5,10 @@
  */
 struct ArkBlueprint {
     private(set) var rules: [Rule] = []
-    mutating func rules<Event: ArkEvent>(on eventType: Event.Type,
-                                         then action: Action) -> Self {
-        rules.append(Rule(event: Event.id, action: action))
-        return self
+    func rules<Event: ArkEvent>(on eventType: Event.Type,
+                                         then action: Action) -> ArkBlueprint {
+        var rulesCopy = rules
+        rulesCopy.append(Rule(event: Event.id, action: action))
+        return ArkBlueprint(rules: rulesCopy)
     }
 }

--- a/ArkKit/ArkBlueprint.swift
+++ b/ArkKit/ArkBlueprint.swift
@@ -1,0 +1,8 @@
+struct ArkBlueprint {
+    private(set) var rules: [Rule] = []
+    mutating func rules<Event: ArkEvent>(on eventType: Event.Type,
+                                         then action: Action) -> Self {
+        rules.append(Rule(event: Event.id, action: action))
+        return self
+    }
+}

--- a/ArkKit/ViewController.swift
+++ b/ArkKit/ViewController.swift
@@ -10,8 +10,24 @@ class ViewController: UIViewController {
 
         let joystick = UIKitJoystick(center: CGPoint(x: midX, y: midY), radius: 50)
         joystick.render(into: self.view)
-//        let button = UIKitButton(width: 100, height: 100, center: CGPoint(x: midX, y: midY))
-//        button.backgroundColor = .red
-//        button.render(into: self.view)
+        var arkBlueprint = ArkBlueprint()
+        arkBlueprint.rules(on: DemoArkEvent.self, then: Forever { event, _, ecsContext in
+            guard event is DemoArkEvent else {
+                print("in gaurd")
+                return
+            }
+            // dev can mutate ecs via here
+            print(ecsContext.getEntities(with: []))
+        })
+        print("blueprint", arkBlueprint)
+        let ark = Ark(rootView: UINavigationController())
+        ark.start(blueprint: arkBlueprint)
+        var demoEvent: any ArkEvent = DemoArkEvent()
+        ark.eventContext.emit(&demoEvent)
+        print("emitting first event", demoEvent)
+        ark.eventContext.processEvents()
+        print("emitting second event", demoEvent)
+        ark.eventContext.emit(&demoEvent)
+        ark.eventContext.processEvents()
     }
 }

--- a/ArkKit/ViewController.swift
+++ b/ArkKit/ViewController.swift
@@ -10,24 +10,5 @@ class ViewController: UIViewController {
 
         let joystick = UIKitJoystick(center: CGPoint(x: midX, y: midY), radius: 50)
         joystick.render(into: self.view)
-        var arkBlueprint = ArkBlueprint()
-        arkBlueprint.rules(on: DemoArkEvent.self, then: Forever { event, _, ecsContext in
-            guard event is DemoArkEvent else {
-                print("in gaurd")
-                return
-            }
-            // dev can mutate ecs via here
-            print(ecsContext.getEntities(with: []))
-        })
-        print("blueprint", arkBlueprint)
-        let ark = Ark(rootView: UINavigationController())
-        ark.start(blueprint: arkBlueprint)
-        var demoEvent: any ArkEvent = DemoArkEvent()
-        ark.eventContext.emit(&demoEvent)
-        print("emitting first event", demoEvent)
-        ark.eventContext.processEvents()
-        print("emitting second event", demoEvent)
-        ark.eventContext.emit(&demoEvent)
-        ark.eventContext.processEvents()
     }
 }

--- a/ArkKit/ark-event-kit/ArkEventContext.swift
+++ b/ArkKit/ark-event-kit/ArkEventContext.swift
@@ -1,0 +1,4 @@
+protocol ArkEventContext {
+    func emit(_ event: inout ArkEvent)
+    func subscribe(to eventId: ArkEventID, listener: @escaping (ArkEvent) -> Void)
+}

--- a/ArkKit/ark-event-kit/ArkEventManager.swift
+++ b/ArkKit/ark-event-kit/ArkEventManager.swift
@@ -12,12 +12,10 @@ class ArkEventManager: ArkEventContext {
     private var eventQueue = PriorityQueue<ArkEvent>(sort: ArkEventManager.compareEventPriority)
 
     func subscribe(to eventId: ArkEventID, listener: @escaping (ArkEvent) -> Void) {
-        print("start subsribe", listeners)
         if listeners[eventId] == nil {
             listeners[eventId] = []
         }
         self.listeners[eventId]?.append(listener)
-        print("end subsribe", listeners)
     }
 
     func emit(_ event: inout ArkEvent) {
@@ -26,7 +24,6 @@ class ArkEventManager: ArkEventContext {
     }
 
     func processEvents() {
-        print("start processEvents", listeners)
         // If events generate more events, the new events will be processed in the next cycle
         var processingEventQueue = eventQueue
         eventQueue = PriorityQueue<ArkEvent>(sort: ArkEventManager.compareEventPriority)
@@ -40,15 +37,10 @@ class ArkEventManager: ArkEventContext {
             listenersToExecute.forEach { listener in
                 listener(event)
             }
+            // removes all listeners that have been executed
             listeners[type(of: event).id] = Array(listeners[type(of: event).id]?
                 .suffix(from: listenersToExecute.count) ?? [])
-
-//            listeners[type(of: event).id]?.forEach { listener in
-//                listener(event)
-//            }
-
         }
-        print("end processEvents", listeners)
     }
 
     private static func compareEventPriority(event1: ArkEvent, event2: ArkEvent) -> Bool {

--- a/ArkKit/ark-event-kit/ArkEventManager.swift
+++ b/ArkKit/ark-event-kit/ArkEventManager.swift
@@ -15,7 +15,7 @@ class ArkEventManager: ArkEventContext {
         if listeners[eventId] == nil {
             listeners[eventId] = []
         }
-        self.listeners[eventId]?.append(listener)
+        listeners[eventId]?.append(listener)
     }
 
     func emit(_ event: inout ArkEvent) {

--- a/ArkKit/ark-event-kit/ArkEventManager.swift
+++ b/ArkKit/ark-event-kit/ArkEventManager.swift
@@ -7,15 +7,15 @@
 
 import Foundation
 
-class ArkEventManager {
-    private var listeners = [ArkEventID: [(ArkEvent) -> Void]]()
+class ArkEventManager: ArkEventContext {
+    private var listeners: [ArkEventID: [(ArkEvent) -> Void]] = [:]
     private var eventQueue = PriorityQueue<ArkEvent>(sort: ArkEventManager.compareEventPriority)
 
     func subscribe(to eventId: ArkEventID, listener: @escaping (ArkEvent) -> Void) {
         if listeners[eventId] == nil {
             listeners[eventId] = []
         }
-        listeners[eventId]?.append(listener)
+        self.listeners[eventId]?.append(listener)
     }
 
     func emit(_ event: inout ArkEvent) {
@@ -27,15 +27,14 @@ class ArkEventManager {
         // If events generate more events, the new events will be processed in the next cycle
         var processingEventQueue = eventQueue
         eventQueue = PriorityQueue<ArkEvent>(sort: ArkEventManager.compareEventPriority)
-
         while !processingEventQueue.isEmpty {
-            guard let event = eventQueue.dequeue() else {
+            guard let event = processingEventQueue.dequeue() else {
                 fatalError("[ArkEventManager.processEvents()] dequeue failed: Expected event, found nil.")
             }
-
             listeners[type(of: event).id]?.forEach { listener in
                 listener(event)
             }
+            self.listeners[type(of: event).id] = []
         }
     }
 

--- a/ArkKit/ark-event-kit/ArkEventManager.swift
+++ b/ArkKit/ark-event-kit/ArkEventManager.swift
@@ -12,10 +12,12 @@ class ArkEventManager: ArkEventContext {
     private var eventQueue = PriorityQueue<ArkEvent>(sort: ArkEventManager.compareEventPriority)
 
     func subscribe(to eventId: ArkEventID, listener: @escaping (ArkEvent) -> Void) {
+        print("start subsribe", listeners)
         if listeners[eventId] == nil {
             listeners[eventId] = []
         }
         self.listeners[eventId]?.append(listener)
+        print("end subsribe", listeners)
     }
 
     func emit(_ event: inout ArkEvent) {
@@ -24,6 +26,7 @@ class ArkEventManager: ArkEventContext {
     }
 
     func processEvents() {
+        print("start processEvents", listeners)
         // If events generate more events, the new events will be processed in the next cycle
         var processingEventQueue = eventQueue
         eventQueue = PriorityQueue<ArkEvent>(sort: ArkEventManager.compareEventPriority)
@@ -31,11 +34,21 @@ class ArkEventManager: ArkEventContext {
             guard let event = processingEventQueue.dequeue() else {
                 fatalError("[ArkEventManager.processEvents()] dequeue failed: Expected event, found nil.")
             }
-            listeners[type(of: event).id]?.forEach { listener in
+            guard let listenersToExecute = listeners[type(of: event).id] else {
+                return
+            }
+            listenersToExecute.forEach { listener in
                 listener(event)
             }
-            self.listeners[type(of: event).id] = []
+            listeners[type(of: event).id] = Array(listeners[type(of: event).id]?
+                .suffix(from: listenersToExecute.count) ?? [])
+
+//            listeners[type(of: event).id]?.forEach { listener in
+//                listener(event)
+//            }
+
         }
+        print("end processEvents", listeners)
     }
 
     private static func compareEventPriority(event1: ArkEvent, event2: ArkEvent) -> Bool {

--- a/ArkKit/ark-event-kit/DemoArkEvent.swift
+++ b/ArkKit/ark-event-kit/DemoArkEvent.swift
@@ -37,7 +37,7 @@ struct DemoArkEvent: ArkEvent {
 struct DemoArkEventTest {
     /// Subscribes to DemoArkEvent and handles it by printing event data.
     /// - Parameter em: The ArkEventManager instance used for managing events.
-    static func testSubscribe(_ em: ArkEventManager) {
+    static func testSubscribe(_ em: ArkEventContext) {
         em.subscribe(to: DemoArkEvent.id) { (event: ArkEvent) -> Void in
             // Cast the generic ArkEvent to a specific type to access its data.
             guard let eventData = event.eventData as? DemoArkEventData else {

--- a/ArkKit/ark-rules-kit/action/Action.swift
+++ b/ArkKit/ark-rules-kit/action/Action.swift
@@ -1,0 +1,5 @@
+protocol Action {
+    func execute<Event: ArkEvent>(_ event: Event,
+                                  eventContext: ArkEventContext,
+                                  ecsContext: ArkECSContext)
+}

--- a/ArkKit/ark-rules-kit/action/Forever.swift
+++ b/ArkKit/ark-rules-kit/action/Forever.swift
@@ -1,0 +1,15 @@
+struct Forever: Action {
+    private let callback: (any ArkEvent, ArkEventContext, ArkECSContext) -> Void
+    init(_ callback: @escaping (any ArkEvent, ArkEventContext, ArkECSContext) -> Void) {
+        self.callback = callback
+    }
+    func execute<Event: ArkEvent>(_ event: Event, eventContext: ArkEventContext, ecsContext: ArkECSContext) {
+        callback(event, eventContext, ecsContext)
+        eventContext.subscribe(to: Event.id) { (nextEvent: any ArkEvent) -> Void in
+            guard let castedEvent = nextEvent as? Event else {
+                return
+            }
+            callback(castedEvent, eventContext, ecsContext)
+        }
+    }
+}

--- a/ArkKit/ark-rules-kit/action/Forever.swift
+++ b/ArkKit/ark-rules-kit/action/Forever.swift
@@ -5,11 +5,12 @@ struct Forever: Action {
     }
     func execute<Event: ArkEvent>(_ event: Event, eventContext: ArkEventContext, ecsContext: ArkECSContext) {
         callback(event, eventContext, ecsContext)
+        let nextForever = self
         eventContext.subscribe(to: Event.id) { (nextEvent: any ArkEvent) -> Void in
             guard let castedEvent = nextEvent as? Event else {
                 return
             }
-            callback(castedEvent, eventContext, ecsContext)
+            nextForever.execute(castedEvent, eventContext: eventContext, ecsContext: ecsContext)
         }
     }
 }

--- a/ArkKit/ark-rules-kit/action/Once.swift
+++ b/ArkKit/ark-rules-kit/action/Once.swift
@@ -1,0 +1,9 @@
+struct Once: Action {
+    private let callback: (ArkEvent, ArkEventContext, ArkECSContext) -> Void
+    init(_ callback: @escaping (ArkEvent, ArkEventContext, ArkECSContext) -> Void) {
+        self.callback = callback
+    }
+    func execute<Event: ArkEvent>(_ event: Event, eventContext: ArkEventContext, ecsContext: ArkECSContext) {
+        callback(event, eventContext, ecsContext)
+    }
+}

--- a/ArkKit/ark-rules-kit/rule/Rule.swift
+++ b/ArkKit/ark-rules-kit/rule/Rule.swift
@@ -1,0 +1,4 @@
+struct Rule {
+    let event: ArkEventID
+    let action: Action
+}

--- a/ArkKit/ark-state-kit/ArkECSContext.swift
+++ b/ArkKit/ark-state-kit/ArkECSContext.swift
@@ -1,0 +1,9 @@
+protocol ArkECSContext {
+    func createEntity() -> Entity
+    func removeEntity(_ entity: Entity)
+    func upsertComponent<T: Component>(_ component: T, to entity: Entity)
+    func getComponent<T: Component>(ofType type: T.Type, for entity: Entity) -> T?
+    func createEntity(with components: [Component]) -> Entity
+    func getEntities(with componentTypes: [Component.Type]) -> [Entity]
+    func getComponents(from entity: Entity) -> [Component]
+}

--- a/ArkKit/ark-state-kit/ArkState.swift
+++ b/ArkKit/ark-state-kit/ArkState.swift
@@ -9,7 +9,7 @@ import Foundation
 
 class ArkState {
     private let arkECS: ArkECS
-    var eventManager: ArkEventManager
+    let eventManager: ArkEventManager
 
     init(eventManager: ArkEventManager, arkECS: ArkECS) {
         self.arkECS = arkECS

--- a/ArkKit/ark-state-kit/ArkState.swift
+++ b/ArkKit/ark-state-kit/ArkState.swift
@@ -9,10 +9,10 @@ import Foundation
 
 class ArkState {
     private let arkECS: ArkECS
-    let eventManager: ArkEventManager
+    var eventManager: ArkEventManager
 
-    init(eventManager: ArkEventManager = ArkEventManager()) {
-        self.arkECS = ArkECS()
+    init(eventManager: ArkEventManager, arkECS: ArkECS) {
+        self.arkECS = arkECS
         self.eventManager = eventManager
     }
 
@@ -20,5 +20,4 @@ class ArkState {
         arkECS.update(deltaTime: deltaTime)
         eventManager.processEvents()
     }
-
 }

--- a/ArkKit/ark-state-kit/ArkStateEventListener.swift
+++ b/ArkKit/ark-state-kit/ArkStateEventListener.swift
@@ -9,9 +9,9 @@ import Foundation
 
 struct ArkStateEventListener {
     private let arkECS: ArkECS
-    private let arkEventManager: ArkEventManager
+    private let arkEventManager: ArkEventContext
 
-    init(arkECS: ArkECS, arkEventManager: ArkEventManager) {
+    init(arkECS: ArkECS, arkEventManager: ArkEventContext) {
         self.arkECS = arkECS
         self.arkEventManager = arkEventManager
     }

--- a/ArkKit/ark-state-kit/ark-ecs-kit/ArkECS.swift
+++ b/ArkKit/ark-state-kit/ark-ecs-kit/ArkECS.swift
@@ -21,3 +21,33 @@ class ArkECS {
     }
 
 }
+
+extension ArkECS: ArkECSContext {
+    func createEntity() -> Entity {
+        entityManager.createEntity()
+    }
+
+    func removeEntity(_ entity: Entity) {
+        entityManager.removeEntity(entity)
+    }
+
+    func upsertComponent<T>(_ component: T, to entity: Entity) where T: Component {
+        entityManager.upsertComponent(component, to: entity)
+    }
+
+    func getComponent<T>(ofType type: T.Type, for entity: Entity) -> T? where T: Component {
+        entityManager.getComponent(ofType: type, for: entity)
+    }
+
+    func createEntity(with components: [any Component]) -> Entity {
+        entityManager.createEntity(with: components)
+    }
+
+    func getEntities(with componentTypes: [any Component.Type]) -> [Entity] {
+        entityManager.getEntities(with: componentTypes)
+    }
+
+    func getComponents(from entity: Entity) -> [any Component] {
+        entityManager.getComponents(from: entity)
+    }
+}

--- a/ArkKit/ark-state-kit/ark-ecs-kit/Component.swift
+++ b/ArkKit/ark-state-kit/ark-ecs-kit/Component.swift
@@ -1,14 +1,6 @@
-//
-//  Component.swift
-//  LevelKit
-//
-//  Created by Ryan Peh on 9/3/24.
-//
-
 import Foundation
 
 typealias ComponentID = UUID
 
 protocol Component {
-    var entityID: EntityID { get set }
 }

--- a/ArkKit/ark-ui-kit-renderer/coordinator/ArkGameCoordinator.swift
+++ b/ArkKit/ark-ui-kit-renderer/coordinator/ArkGameCoordinator.swift
@@ -3,13 +3,15 @@ import UIKit
 class ArkGameCoordinator {
     let rootView: UINavigationController
     let eventManager: ArkEventManager
-    init(rootView: UINavigationController, eventManager: ArkEventManager) {
+    let arkECS: ArkECS
+    init(rootView: UINavigationController, eventManager: ArkEventManager, arkECS: ArkECS) {
         self.rootView = rootView
         self.eventManager = eventManager
+        self.arkECS = arkECS
     }
     func start() {
         // initiate key M, V, VM
-        let arkGameModel = ArkGameModel(eventManager: eventManager)
+        let arkGameModel = ArkGameModel(eventManager: eventManager, arkECS: arkECS)
         let arkViewController = ArkViewController()
         let arkViewModel = ArkViewModel(gameModel: arkGameModel)
 

--- a/ArkKit/ark-ui-kit-renderer/model/ArkGameModel.swift
+++ b/ArkKit/ark-ui-kit-renderer/model/ArkGameModel.swift
@@ -1,7 +1,7 @@
 class ArkGameModel {
     var gameState: ArkState?
-    init(eventManager: ArkEventManager) {
-        gameState = ArkState(eventManager: eventManager)
+    init(eventManager: ArkEventManager, arkECS: ArkECS) {
+        gameState = ArkState(eventManager: eventManager, arkECS: arkECS)
     }
     func updateState(dt: Double) {
         gameState?.update(deltaTime: dt)

--- a/ArkKitTests/ArkKitTests.swift
+++ b/ArkKitTests/ArkKitTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-@testable import LevelKit
+@testable import ArkKit
 
 final class LevelKitTests: XCTestCase {
 


### PR DESCRIPTION
### Key Changes
- Moved `ArkBlueprint` as separate from `Ark` instance.
- Implemented `ark-rules`, which can be instantiated from `ArkBlueprint`, and loaded into `Ark` via `Ark.start()`
- Implemented `Rules` and `Action`, and separated the corresponding `ArkEventContext` and `ArkECSContext` into protocols so that `Action` can use the contexts for modification without dependency on `ArkEventManager` and `ArkECS` concrete implementations. 

### Implementation

**Actions**:
- Support 2 types of actions: `Once` and `Forever`.
- `Once` describes an action that will not produce any more actions after the action is executed for future same event types. i.e. action is only executed once. If the event occurs again, the action is no longer executed.
- `Forever` describes an action that will produce more actions of itself after it is executed, so that future same events will result in an execution. i.e. as long as the event occurs, the forever action is executed.

**ArkBlueprint**:
- Immutable version to allow for method-chaining
- Also better tracks blueprint's definition at each stage incrementally

### Example Usage
```swift
let arkBlueprint = ArkBlueprint().rules(on: DemoArkEvent.self, then: Forever { event, eventContext, ecsContext in
    guard event is DemoArkEvent else {
        return
    }
    // dev can mutate ecs state via ecsContext
    // dev can mutate/ emit/ subscribe to events via eventContext
    // dev can read event details via event
    print("execute forever callback")
}).rules(on: DemoArkEvent.self, then: Once { _, _, _ in
    print("execute once callback")
})

let ark = Ark(rootView: UINavigationController()) // pass in rootView to Ark game instance
ark.start(blueprint: arkBlueprint)
```