### PR TITLE
[ark-blueprint, ark] fix: strongly reference ark in scene delegate

### DIFF
--- a/ArkGameExample/SceneDelegate.swift
+++ b/ArkGameExample/SceneDelegate.swift
@@ -3,6 +3,7 @@ import UIKit
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
+    private var ark: Ark?
 
     func scene(_ scene: UIScene,
                willConnectTo session: UISceneSession,
@@ -55,12 +56,27 @@ extension SceneDelegate {
     func defineArkBlueprint() -> ArkBlueprint {
         // Define game with blueprint here.
         let arkBlueprint = ArkBlueprint()
-            .ecsSetup({ ecsContext in
+            .stateSetup({ ecsContext, eventContext in
                 _ = ecsContext.createEntity(with: [
                     JoystickCanvasComponent(center: CGPoint(x: 300, y: 300), radius: 50,
                                             areValuesEqual: { _, _ in true })
-                        .addPanChangeDelegate(delegate: { angle, mag in print(angle, mag) })
+                        .addPanChangeDelegate(delegate: { angle, mag in print("change", angle, mag) })
+                        .addPanStartDelegate(delegate: { angle, mag in print("start", angle, mag) })
+                        .addPanEndDelegate(delegate: { angle, mag in print("end", angle, mag) })
                 ])
+                _ = ecsContext.createEntity(with: [
+                    ButtonCanvasComponent(width: 50, height: 50, center: CGPoint(x: 500, y: 500),
+                                          areValuesEqual: { _, _ in true })
+                    .addOnTapDelegate(delegate: {
+                        print("emiting event")
+                        var demoEvent: any ArkEvent = DemoArkEvent()
+                        eventContext.emit(&demoEvent)
+                        print("done emit event")
+                    })
+                ])
+            })
+            .rule(on: DemoArkEvent.self, then: Forever { _, _, _ in
+                print("running rule")
             })
         return arkBlueprint
     }
@@ -68,7 +84,7 @@ extension SceneDelegate {
         guard let rootView = window.rootViewController as? UINavigationController else {
             return
         }
-        let arkInstance = Ark(rootView: rootView)
-        arkInstance.start(blueprint: blueprint)
+        self.ark = Ark(rootView: rootView)
+        ark?.start(blueprint: blueprint)
     }
 }

--- a/ArkGameExample/SceneDelegate.swift
+++ b/ArkGameExample/SceneDelegate.swift
@@ -57,14 +57,14 @@ extension SceneDelegate {
         // Define game with blueprint here.
         let arkBlueprint = ArkBlueprint()
             .stateSetup({ ecsContext, eventContext in
-                _ = ecsContext.createEntity(with: [
+                ecsContext.createEntity(with: [
                     JoystickCanvasComponent(center: CGPoint(x: 300, y: 300), radius: 50,
                                             areValuesEqual: { _, _ in true })
                         .addPanChangeDelegate(delegate: { angle, mag in print("change", angle, mag) })
                         .addPanStartDelegate(delegate: { angle, mag in print("start", angle, mag) })
                         .addPanEndDelegate(delegate: { angle, mag in print("end", angle, mag) })
                 ])
-                _ = ecsContext.createEntity(with: [
+                ecsContext.createEntity(with: [
                     ButtonCanvasComponent(width: 50, height: 50, center: CGPoint(x: 500, y: 500),
                                           areValuesEqual: { _, _ in true })
                     .addOnTapDelegate(delegate: {

--- a/ArkKit.xcodeproj/project.pbxproj
+++ b/ArkKit.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		02C395282BA891AA0075F1CA /* ArkUIKitCanvasRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C395272BA891AA0075F1CA /* ArkUIKitCanvasRenderer.swift */; };
 		02C3952A2BA8952F0075F1CA /* CanvasContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C395292BA8952F0075F1CA /* CanvasContext.swift */; };
 		02C3952C2BA897890075F1CA /* ArkCanvas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C3952B2BA897890075F1CA /* ArkCanvas.swift */; };
+		02C395322BA9ED230075F1CA /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 02C395312BA9ED230075F1CA /* README.md */; };
 		02E0E8EE2BA280BD0043E2BA /* UIKitShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E0E8ED2BA280BD0043E2BA /* UIKitShape.swift */; };
 		02E0E8F02BA280DB0043E2BA /* UIKitRenderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E0E8EF2BA280DB0043E2BA /* UIKitRenderable.swift */; };
 		02E0E8F22BA282C20043E2BA /* UIKitCircle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E0E8F12BA282C20043E2BA /* UIKitCircle.swift */; };
@@ -140,6 +141,7 @@
 		02C395272BA891AA0075F1CA /* ArkUIKitCanvasRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArkUIKitCanvasRenderer.swift; sourceTree = "<group>"; };
 		02C395292BA8952F0075F1CA /* CanvasContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasContext.swift; sourceTree = "<group>"; };
 		02C3952B2BA897890075F1CA /* ArkCanvas.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArkCanvas.swift; sourceTree = "<group>"; };
+		02C395312BA9ED230075F1CA /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		02E0E8ED2BA280BD0043E2BA /* UIKitShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitShape.swift; sourceTree = "<group>"; };
 		02E0E8EF2BA280DB0043E2BA /* UIKitRenderable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitRenderable.swift; sourceTree = "<group>"; };
 		02E0E8F12BA282C20043E2BA /* UIKitCircle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitCircle.swift; sourceTree = "<group>"; };
@@ -595,6 +597,7 @@
 		AD787A442B9C636F003EBBD0 = {
 			isa = PBXGroup;
 			children = (
+				02C395312BA9ED230075F1CA /* README.md */,
 				02C395102BA6EBBA0075F1CA /* ArkGameExample */,
 				AD787A4F2B9C636F003EBBD0 /* ArkKit */,
 				AD787A662B9C6373003EBBD0 /* ArkKitTests */,
@@ -755,6 +758,7 @@
 			files = (
 				AD787A5D2B9C6373003EBBD0 /* LaunchScreen.storyboard in Resources */,
 				AD787A5A2B9C6373003EBBD0 /* Assets.xcassets in Resources */,
+				02C395322BA9ED230075F1CA /* README.md in Resources */,
 				AD787A582B9C636F003EBBD0 /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ArkKit/ArkBlueprint.swift
+++ b/ArkKit/ArkBlueprint.swift
@@ -5,8 +5,7 @@
  */
 struct ArkBlueprint {
     private(set) var rules: [Rule] = []
-    private(set) var animations: [ArkAnimation<Any>] = []
-    private(set) var ecsSetupFunctions: [ECSSetupFunction] = []
+    private(set) var stateSetupFunctions: [ArkStateSetupFunction] = []
 
     func rule<Event: ArkEvent>(
         on eventType: Event.Type,
@@ -17,27 +16,19 @@ struct ArkBlueprint {
         return immutableCopy(rules: rulesCopy)
     }
 
-    func animation(_ animation: ArkAnimation<Any>) -> ArkBlueprint {
-        var animationsCopy = animations
-        animationsCopy.append(animation)
-        return immutableCopy(animations: animationsCopy)
-    }
-
-    func ecsSetup(_ fn: @escaping ECSSetupFunction) -> ArkBlueprint {
-        var ecsSetupFunctionsCopy = ecsSetupFunctions
-        ecsSetupFunctionsCopy.append(fn)
-        return immutableCopy(ecsSetupFunctions: ecsSetupFunctionsCopy)
+    func stateSetup(_ fn: @escaping ArkStateSetupFunction) -> ArkBlueprint {
+        var stateSetupFunctionsCopy = stateSetupFunctions
+        stateSetupFunctionsCopy.append(fn)
+        return immutableCopy(stateSetupFunctions: stateSetupFunctionsCopy)
     }
 
     private func immutableCopy(
         rules: [Rule]? = nil,
-        animations: [ArkAnimation<Any>]? = nil,
-        ecsSetupFunctions: [ECSSetupFunction]? = nil
+        stateSetupFunctions: [ArkStateSetupFunction]? = nil
     ) -> ArkBlueprint {
         ArkBlueprint(
             rules: rules ?? self.rules,
-            animations: animations ?? self.animations,
-            ecsSetupFunctions: ecsSetupFunctions ?? self.ecsSetupFunctions
+            stateSetupFunctions: stateSetupFunctions ?? self.stateSetupFunctions
         )
     }
 }

--- a/ArkKit/ark-state-kit/ArkECSContext.swift
+++ b/ArkKit/ark-state-kit/ArkECSContext.swift
@@ -6,4 +6,5 @@ protocol ArkECSContext {
     func createEntity(with components: [Component]) -> Entity
     func getEntities(with componentTypes: [Component.Type]) -> [Entity]
     func getComponents(from entity: Entity) -> [Component]
+    func addSystem(_ system: System)
 }

--- a/ArkKit/ark-state-kit/ArkECSContext.swift
+++ b/ArkKit/ark-state-kit/ArkECSContext.swift
@@ -1,9 +1,9 @@
 protocol ArkECSContext {
-    func createEntity() -> Entity
+    @discardableResult func createEntity() -> Entity
     func removeEntity(_ entity: Entity)
     func upsertComponent<T: Component>(_ component: T, to entity: Entity)
     func getComponent<T: Component>(ofType type: T.Type, for entity: Entity) -> T?
-    func createEntity(with components: [Component]) -> Entity
+    @discardableResult func createEntity(with components: [Component]) -> Entity
     func getEntities(with componentTypes: [Component.Type]) -> [Entity]
     func getComponents(from entity: Entity) -> [Component]
     func addSystem(_ system: System)

--- a/ArkKit/ark-state-kit/ArkState.swift
+++ b/ArkKit/ark-state-kit/ArkState.swift
@@ -7,9 +7,11 @@
 
 import Foundation
 
+typealias ArkStateSetupFunction = (_: ArkECSContext, _: ArkEventContext) -> Void
+
 class ArkState {
-    private let arkECS: ArkECS
-    let eventManager: ArkEventManager
+    private(set) var arkECS: ArkECS
+    private(set) var eventManager: ArkEventManager
 
     init(eventManager: ArkEventManager, arkECS: ArkECS) {
         self.arkECS = arkECS
@@ -19,5 +21,9 @@ class ArkState {
     func update(deltaTime: TimeInterval) {
         arkECS.update(deltaTime: deltaTime)
         eventManager.processEvents()
+    }
+
+    func setup(_ setupFunction: ArkStateSetupFunction) {
+        setupFunction(arkECS, eventManager)
     }
 }

--- a/ArkKit/ark-state-kit/ark-ecs-kit/ArkECS.swift
+++ b/ArkKit/ark-state-kit/ark-ecs-kit/ArkECS.swift
@@ -1,13 +1,4 @@
-//
-//  ArkECS.swift
-//  ArkKit
-//
-//  Created by Ryan Peh on 11/3/24.
-//
-
 import Foundation
-
-typealias ECSSetupFunction = (_: ArkECSContext) -> Void
 
 class ArkECS {
     private let entityManager: EntityManager
@@ -20,14 +11,6 @@ class ArkECS {
 
     func update(deltaTime: TimeInterval) {
         systemManager.update(deltaTime: deltaTime, arkECS: self)
-    }
-
-    func addSystem(_ system: System) {
-        systemManager.add(system)
-    }
-
-    func setup(_ setupFunction: ECSSetupFunction) {
-        setupFunction(self)
     }
 }
 
@@ -62,5 +45,9 @@ extension ArkECS: ArkECSContext {
 
     func getComponents(from entity: Entity) -> [any Component] {
         entityManager.getComponents(from: entity)
+    }
+
+    func addSystem(_ system: System) {
+        systemManager.add(system)
     }
 }

--- a/ArkKit/ark-ui-kit-renderer/coordinator/ArkGameCoordinator.swift
+++ b/ArkKit/ark-ui-kit-renderer/coordinator/ArkGameCoordinator.swift
@@ -2,16 +2,16 @@ import UIKit
 
 class ArkGameCoordinator {
     let rootView: UINavigationController
-    let eventManager: ArkEventManager
-    let arkECS: ArkECS
-    init(rootView: UINavigationController, eventManager: ArkEventManager, arkECS: ArkECS) {
+    let arkState: ArkState
+
+    init(rootView: UINavigationController, arkState: ArkState) {
         self.rootView = rootView
-        self.eventManager = eventManager
-        self.arkECS = arkECS
+        self.arkState = arkState
     }
+
     func start() {
         // initiate key M, V, VM
-        let arkGameModel = ArkGameModel(eventManager: eventManager, arkECS: arkECS)
+        let arkGameModel = ArkGameModel(gameState: arkState)
         let arkViewController = ArkViewController()
         let arkViewModel = ArkViewModel(gameModel: arkGameModel)
 

--- a/ArkKit/ark-ui-kit-renderer/model/ArkGameModel.swift
+++ b/ArkKit/ark-ui-kit-renderer/model/ArkGameModel.swift
@@ -1,9 +1,9 @@
 class ArkGameModel {
     var gameState: ArkState?
     var canvasContext: CanvasContext?
-    init(eventManager: ArkEventManager, arkECS: ArkECS) {
-        gameState = ArkState(eventManager: eventManager, arkECS: arkECS)
-        canvasContext = ArkCanvasContext(ecs: arkECS)
+    init(gameState: ArkState) {
+        self.gameState = gameState
+        canvasContext = ArkCanvasContext(ecs: gameState.arkECS)
     }
     func updateState(dt: Double) {
         gameState?.update(deltaTime: dt)

--- a/ArkKit/ark-ui-kit-renderer/view-components/input/UIKitButton.swift
+++ b/ArkKit/ark-ui-kit-renderer/view-components/input/UIKitButton.swift
@@ -7,6 +7,8 @@ final class UIKitButton: UIButton, UIKitRenderable, TapRenderable {
         let frame = CGRect(x: center.x - width / 2, y: center.y - height / 2,
                            width: width, height: height)
         super.init(frame: frame)
+        // TODO: enable styling of button from abstractButton
+        self.backgroundColor = .brown
         setUpTap()
     }
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# LevelKit
+# ArkKit
+
+## Introduction
+ArkKit is a specialized game framework tailored for event-driven game development, focusing on creating engaging player versus player (PvP) tabletop minigames.
+
+## Features
+- **Event-Driven Architecture**: ArkKit revolves around an event-driven architecture, allowing developers to build games where interactions between players and the game world are driven by events.
+- **Entity-Component-System (ECS)**: ArkKit adopts a hybrid event-centric and entity-component-system architecture, providing developers with a flexible and scalable approach to game development.
+


### PR DESCRIPTION
### Key Changes
- Reference `Ark` instance strongly in the SceneDelegate so that `event` subscriptions can weakly reference the instance
- Replace all `ecsSetup` with `stateSetup` so that `eventContext` is exposed, allowing for `emitting` of events.

### Test
- Tapping the Button prints the "done emit event" log
```swift
func defineArkBlueprint() -> ArkBlueprint {
    // Define game with blueprint here.
    let arkBlueprint = ArkBlueprint()
        .stateSetup({ ecsContext, eventContext in
            _ = ecsContext.createEntity(with: [
                JoystickCanvasComponent(center: CGPoint(x: 300, y: 300), radius: 50,
                                        areValuesEqual: { _, _ in true })
                    .addPanChangeDelegate(delegate: { angle, mag in print("change", angle, mag) })
                    .addPanStartDelegate(delegate: { angle, mag in print("start", angle, mag) })
                    .addPanEndDelegate(delegate: { angle, mag in print("end", angle, mag) })
            ])
            _ = ecsContext.createEntity(with: [
                ButtonCanvasComponent(width: 50, height: 50, center: CGPoint(x: 500, y: 500),
                                      areValuesEqual: { _, _ in true })
                .addOnTapDelegate(delegate: {
                    print("emiting event")
                    var demoEvent: any ArkEvent = DemoArkEvent()
                    eventContext.emit(&demoEvent)
                    print("done emit event")
                })
            ])
        })
        .rule(on: DemoArkEvent.self, then: Forever { _, _, _ in
            print("running rule")
        })
    return arkBlueprint
}
```