### PR TITLE
refactor: make events generic

### DIFF
--- a/ArkGameExample/SceneDelegate.swift
+++ b/ArkGameExample/SceneDelegate.swift
@@ -55,8 +55,11 @@ extension SceneDelegate {
     func defineArkBlueprint() -> ArkBlueprint {
         // Define game with blueprint here.
         let arkBlueprint = ArkBlueprint(frameWidth: 820, frameHeight: 1_180)
-            .setup { ecsContext, eventContext in
-                ecsContext.createEntity(with: [
+            .setup { context in
+                let ecs = context.ecs
+                let events = context.events
+                
+                ecs.createEntity(with: [
                     JoystickCanvasComponent(radius: 50,
                                             areValuesEqual: { _, _ in true })
                         .center(x: 300, y: 300)
@@ -64,18 +67,18 @@ extension SceneDelegate {
                         .onPanStart { angle, mag in print("start", angle, mag) }
                         .onPanEnd { angle, mag in print("end", angle, mag) }
                 ])
-                ecsContext.createEntity(with: [
+                ecs.createEntity(with: [
                     ButtonCanvasComponent(width: 50, height: 50,
                                           areValuesEqual: { _, _ in true })
                         .center(x: 500, y: 500)
                         .onTap {
                             print("emiting event")
                             var demoEvent: any ArkEvent = DemoArkEvent()
-                            eventContext.emit(&demoEvent)
+                            events.emit(&demoEvent)
                             print("done emit event")
                         }
                 ])
-                ecsContext.createEntity(with: [
+                ecs.createEntity(with: [
                     BitmapImageCanvasComponent(imageResourcePath: "tank_1",
                                                width: 256, height: 100,
                                                areValuesEqual: { _, _ in true })
@@ -83,7 +86,7 @@ extension SceneDelegate {
                     .scaleToFill()
                 ])
             }
-            .rule(on: DemoArkEvent.self, then: Forever { _, _, _ in
+            .rule(on: DemoArkEvent.self, then: Forever { _, _ in
                 print("running rule")
             })
         return arkBlueprint

--- a/ArkGameExample/TankGame/Events/TankMoveEvent.swift
+++ b/ArkGameExample/TankGame/Events/TankMoveEvent.swift
@@ -17,11 +17,11 @@ struct TankMoveEventData: ArkEventData {
 struct TankMoveEvent: ArkEvent {
 
     static var id = UUID()
-    var eventData: ArkEventData?
+    var eventData: TankMoveEventData?
     var timestamp = Date()
     var priority: Int?
 
-    init(eventData: ArkEventData? = nil, priority: Int? = nil) {
+    init(eventData: TankMoveEventData? = nil, priority: Int? = nil) {
         self.eventData = eventData
         self.priority = priority
     }

--- a/ArkGameExample/TankGame/Events/TankShootEvent.swift
+++ b/ArkGameExample/TankGame/Events/TankShootEvent.swift
@@ -13,13 +13,12 @@ struct TankShootEventData: ArkEventData {
 }
 
 struct TankShootEvent: ArkEvent {
-
     static var id = UUID()
-    var eventData: ArkEventData?
+    var eventData: TankShootEventData?
     var timestamp = Date()
     var priority: Int?
 
-    init(eventData: ArkEventData? = nil, priority: Int? = nil) {
+    init(eventData: TankShootEventData? = nil, priority: Int? = nil) {
         self.eventData = eventData
         self.priority = priority
     }

--- a/ArkGameExample/TankGame/TankGameManager.swift
+++ b/ArkGameExample/TankGame/TankGameManager.swift
@@ -18,25 +18,28 @@ class TankGameManager {
     func setUpEntities() {
         // Define game with blueprint here.
         self.blueprint = self.blueprint
-            .setup({ ecsContext, eventContext in
+            .setup { context in
+                let ecs = context.ecs
+                let events = context.events
+                
                 let tankEntity1 = TankGameEntityCreator.createTank(at: CGPoint(x: 500, y: 700), rotation: Double.pi,
-                                                                   tankIndex: 1, in: ecsContext)
+                                                                   tankIndex: 1, in: ecs)
                 let tankEntity2 = TankGameEntityCreator.createTank(at: CGPoint(x: 500, y: 300), rotation: 0,
-                                                                   tankIndex: 2, in: ecsContext)
+                                                                   tankIndex: 2, in: ecs)
 
                 TankGameEntityCreator.createJoyStick(center: CGPoint(x: 150, y: 1_030), tankEntity: tankEntity1,
-                                                     in: ecsContext, eventContext: eventContext)
+                                                     in: ecs, eventContext: events)
                 TankGameEntityCreator.createJoyStick(center: CGPoint(x: 670, y: 150), tankEntity: tankEntity2,
-                                                     in: ecsContext, eventContext: eventContext)
+                                                     in: ecs, eventContext: events)
 
                 TankGameEntityCreator.createShootButton(at: CGPoint(x: 670, y: 1_030), tankEntity: tankEntity1,
-                                                        in: ecsContext, eventContext: eventContext)
+                                                        in: ecs, eventContext: events)
                 TankGameEntityCreator.createShootButton(at: CGPoint(x: 150, y: 150), tankEntity: tankEntity2,
-                                                        in: ecsContext, eventContext: eventContext)
+                                                        in: ecs, eventContext: events)
 
 //                TankGameEntityCreator.addBackground(width: self.blueprint.frameWidth, height: self.blueprint.frameHeight,
-//                                                    in: ecsContext)
-            })
+//                                                    in: ecs)
+            }
 
     }
 
@@ -44,43 +47,54 @@ class TankGameManager {
     }
 
     func setUpRules() {
-        self.blueprint = self.blueprint
-            .rule(on: TankMoveEvent.self, then: Forever { event, _, ecsContext in
-                guard let tankMoveEvent = event as? TankMoveEvent,
-                      let tankMoveEventData = tankMoveEvent.eventData as? TankMoveEventData,
-                      var tankRotationComponent = ecsContext.getComponent(ofType: RotationComponent.self,
-                                                                          for: tankMoveEventData.tankEntity),
-                      var tankPhysicsComponent = ecsContext.getComponent(ofType: PhysicsComponent.self,
-                                                                         for: tankMoveEventData.tankEntity)
-                else {
+        blueprint = blueprint
+            .rule(on: TankMoveEvent.self, then: Forever { event, context in
+                let ecs = context.ecs
+
+                guard let eventData = event.eventData else {
                     return
                 }
 
+                guard var tankRotationComponent = ecs.getComponent(
+                    ofType: RotationComponent.self,
+                    for: eventData.tankEntity)
+                else {
+                    return
+                }
+                
+                guard var tankPhysicsComponent = ecs.getComponent(
+                    ofType: PhysicsComponent.self,
+                    for: eventData.tankEntity)
+                else {
+                    return
+                }
+                
                 let velocityScale = 1.5
 
-                if tankMoveEventData.magnitude == 0 {
-                    tankPhysicsComponent.velocity = .zero
-                    ecsContext.upsertComponent(tankPhysicsComponent, to: tankMoveEventData.tankEntity)
-                } else {
-                    tankRotationComponent.angleInRadians = tankMoveEventData.angle - Double.pi / 2
+                let velocityX = eventData.magnitude * velocityScale
+                    * cos(eventData.angle - Double.pi / 2)
+                let velocityY = eventData.magnitude * velocityScale
+                        * sin(eventData.angle - Double.pi / 2)
 
-                    let velocityX = tankMoveEventData.magnitude * velocityScale
-                                    * cos(tankMoveEventData.angle - Double.pi / 2)
-                    let velocityY = tankMoveEventData.magnitude * velocityScale
-                                    * sin(tankMoveEventData.angle - Double.pi / 2)
-
-                    tankPhysicsComponent.velocity = CGVector(dx: velocityX, dy: velocityY)
-                    ecsContext.upsertComponent(tankPhysicsComponent, to: tankMoveEventData.tankEntity)
-                }
+                tankPhysicsComponent.velocity = CGVector(dx: velocityX, dy: velocityY)
+                ecs.upsertComponent(tankPhysicsComponent, to: eventData.tankEntity)
             })
-            .rule(on: TankShootEvent.self, then: Forever { event, _, ecsContext in
-                guard let tankShootEvent = event as? TankShootEvent,
-                      let tankShootEventData = tankShootEvent.eventData as? TankShootEventData,
-                      let tankPositionComponent = ecsContext.getComponent(ofType: PositionComponent.self,
-                                                                          for: tankShootEventData.tankEntity),
-                      let tankRotationComponent = ecsContext.getComponent(ofType: RotationComponent.self,
-                                                                          for: tankShootEventData.tankEntity)
-                else {
+            .rule(on: TankShootEvent.self, then: Forever { event, context in
+                let ecs = context.ecs
+                
+                guard let eventData = event.eventData else {
+                    return
+                }
+
+                guard let tankPositionComponent = ecs.getComponent(
+                    ofType: PositionComponent.self,
+                    for: eventData.tankEntity) else {
+                    return
+                }
+                
+                guard let tankRotationComponent = ecs.getComponent(
+                        ofType: RotationComponent.self,
+                        for: eventData.tankEntity) else {
                     return
                 }
 
@@ -91,7 +105,7 @@ class TankGameManager {
                                 velocity: CGVector(dx: ballVelocity * cos(tankRotationComponent.angleInRadians ?? 0),
                                                    dy: ballVelocity * sin(tankRotationComponent.angleInRadians ?? 0)),
                                 angle: tankRotationComponent.angleInRadians ?? 0,
-                                in: ecsContext)
+                                in: ecs)
             })
     }
 

--- a/ArkKit.xcodeproj/project.pbxproj
+++ b/ArkKit.xcodeproj/project.pbxproj
@@ -117,6 +117,7 @@
 		8F5573C82BA69D61007030C8 /* ArkAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F5573C72BA69D61007030C8 /* ArkAnimation.swift */; };
 		8F5573CA2BA6A633007030C8 /* ArkAnimationSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F5573C92BA6A633007030C8 /* ArkAnimationSystem.swift */; };
 		8F5573CF2BA6A731007030C8 /* ArkAnimationInstance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F5573CE2BA6A731007030C8 /* ArkAnimationInstance.swift */; };
+		8FEB21832BAE06D700788E20 /* ArkActionContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FEB21822BAE06D700788E20 /* ArkActionContext.swift */; };
 		945F7F852BA55ECA00933629 /* UIKitButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 945F7F842BA55ECA00933629 /* UIKitButton.swift */; };
 		945F7F932BA8861300933629 /* AbstractTappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 945F7F922BA8861300933629 /* AbstractTappable.swift */; };
 		945F7F9B2BA8912200933629 /* AbstractPannable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 945F7F9A2BA8912200933629 /* AbstractPannable.swift */; };
@@ -281,6 +282,7 @@
 		8F5573C72BA69D61007030C8 /* ArkAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArkAnimation.swift; sourceTree = "<group>"; };
 		8F5573C92BA6A633007030C8 /* ArkAnimationSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArkAnimationSystem.swift; sourceTree = "<group>"; };
 		8F5573CE2BA6A731007030C8 /* ArkAnimationInstance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArkAnimationInstance.swift; sourceTree = "<group>"; };
+		8FEB21822BAE06D700788E20 /* ArkActionContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArkActionContext.swift; sourceTree = "<group>"; };
 		945F7F842BA55ECA00933629 /* UIKitButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitButton.swift; sourceTree = "<group>"; };
 		945F7F922BA8861300933629 /* AbstractTappable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbstractTappable.swift; sourceTree = "<group>"; };
 		945F7F9A2BA8912200933629 /* AbstractPannable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbstractPannable.swift; sourceTree = "<group>"; };
@@ -908,6 +910,7 @@
 			children = (
 				02C394E22BA407420075F1CA /* Ark.swift */,
 				02C3950C2BA5FE5C0075F1CA /* ArkBlueprint.swift */,
+				8FEB21822BAE06D700788E20 /* ArkActionContext.swift */,
 				02E0E8DE2B9F57170043E2BA /* ark-game */,
 				02D8E94A2BAC99F100BF3A07 /* ark-loop-kit */,
 				280CD3B52BA738EC00372C5D /* ark-physics-kit */,
@@ -1139,6 +1142,7 @@
 				280CD3CE2BA74E4300372C5D /* BaseSKGameScene.swift in Sources */,
 				280CD3C42BA7419400372C5D /* ArkSceneUpdateDelegate.swift in Sources */,
 				02C3950F2BA611B80075F1CA /* ArkEventContext.swift in Sources */,
+				8FEB21832BAE06D700788E20 /* ArkActionContext.swift in Sources */,
 				28A032DC2BAD4E8200851BFF /* StopWatchComponent.swift in Sources */,
 				945F7F932BA8861300933629 /* AbstractTappable.swift in Sources */,
 				02C394F72BA4428A0075F1CA /* UIKitJoystick.swift in Sources */,

--- a/ArkKit/Ark.swift
+++ b/ArkKit/Ark.swift
@@ -78,9 +78,8 @@ class Ark {
 }
 
 private extension ArkEvent {
-    func cry() {
-        
-    }
+    /// A workaround to prevent weird behavior when trying to execute
+    /// `action.execute(event, context: context)`
     func executeAction(_ action: some Action, context: ArkActionContext) {
         guard let castedAction = action as? any Action<Self> else {
             return

--- a/ArkKit/Ark.swift
+++ b/ArkKit/Ark.swift
@@ -34,21 +34,17 @@ class Ark {
         gameCoordinator.start()
     }
 
-    private func setup(_ rules: [Rule]) {
+    private func setup(_ rules: [any Rule]) {
+        let context = ArkActionContext(ecs: arkState.arkECS, events: arkState.eventManager)
         // subscribe all rules to the eventManager
         for rule in rules {
-            arkState.eventManager.subscribe(to: rule.event) { [weak self] (event: any ArkEvent) -> Void in
-                guard let arkInstance = self else {
-                    return
-                }
-                rule.action.execute(event,
-                                    eventContext: arkInstance.arkState.eventManager,
-                                    ecsContext: arkInstance.arkState.arkECS)
-            }
+            arkState.eventManager.subscribe(to: rule.event, { event in
+                event.executeAction(rule.action, context: context)
+            })
         }
     }
 
-    private func setup(_ stateSetupFunctions: [ArkStateSetupFunction]) {
+    private func setup(_ stateSetupFunctions: [ArkStateSetupDelegate]) {
         for stateSetupFunction in stateSetupFunctions {
             arkState.setup(stateSetupFunction)
         }
@@ -78,5 +74,18 @@ class Ark {
             return (blueprint.frameWidth, blueprint.frameHeight)
         }
         return (worldComponent.width, worldComponent.height)
+    }
+}
+
+private extension ArkEvent {
+    func cry() {
+        
+    }
+    func executeAction(_ action: some Action, context: ArkActionContext) {
+        guard let castedAction = action as? any Action<Self> else {
+            return
+        }
+        
+        castedAction.execute(self, context: context)
     }
 }

--- a/ArkKit/ArkActionContext.swift
+++ b/ArkKit/ArkActionContext.swift
@@ -1,0 +1,4 @@
+struct ArkActionContext {
+    let ecs: ArkECS
+    let events: ArkEventContext
+}

--- a/ArkKit/ArkBlueprint.swift
+++ b/ArkKit/ArkBlueprint.swift
@@ -4,13 +4,13 @@
  * `ArkBlueprint` is effectively the blueprint struct that will be read to return an `Ark` game instance.
  */
 struct ArkBlueprint {
-    private(set) var rules: [Rule] = []
-    private(set) var setupFunctions: [ArkStateSetupFunction] = []
+    private(set) var rules: [any Rule] = []
+    private(set) var setupFunctions: [ArkStateSetupDelegate] = []
 
     private(set) var frameWidth: Double
     private(set) var frameHeight: Double
 
-    func setup(_ fn: @escaping ArkStateSetupFunction) -> Self {
+    func setup(_ fn: @escaping ArkStateSetupDelegate) -> Self {
         var stateSetupFunctionsCopy = setupFunctions
         stateSetupFunctionsCopy.append(fn)
 
@@ -21,10 +21,10 @@ struct ArkBlueprint {
 
     func rule<Event: ArkEvent>(
         on eventType: Event.Type,
-        then action: Action
+        then action: any Action<Event>
     ) -> Self {
         var newRules = rules
-        newRules.append(Rule(event: Event.id, action: action))
+        newRules.append(ArkRule(event: Event.id, action: action))
 
         var newSelf = self
         newSelf.rules = newRules

--- a/ArkKit/ark-event-kit/ArkEvent.swift
+++ b/ArkKit/ark-event-kit/ArkEvent.swift
@@ -9,9 +9,11 @@ import Foundation
 
 typealias ArkEventID = UUID
 
-protocol ArkEvent {
+protocol ArkEvent<Data> {
+    associatedtype Data = ArkEventData
+    
     static var id: ArkEventID { get }
-    var eventData: ArkEventData? { get }
+    var eventData: Data? { get }
     var timestamp: Date { get set }
     var priority: Int? { get set }
 }

--- a/ArkKit/ark-event-kit/ArkEventContext.swift
+++ b/ArkKit/ark-event-kit/ArkEventContext.swift
@@ -1,4 +1,6 @@
 protocol ArkEventContext {
-    func emit(_ event: inout ArkEvent)
-    func subscribe(to eventId: ArkEventID, listener: @escaping (ArkEvent) -> Void)
+    typealias EventListener = (any ArkEvent) -> Void
+    
+    func emit<Event: ArkEvent>(_ event: inout Event)
+    func subscribe(to eventId: ArkEventID, _ listener: @escaping EventListener)
 }

--- a/ArkKit/ark-event-kit/ArkEventManager.swift
+++ b/ArkKit/ark-event-kit/ArkEventManager.swift
@@ -8,17 +8,18 @@
 import Foundation
 
 class ArkEventManager: ArkEventContext {
-    private var listeners: [ArkEventID: [(ArkEvent) -> Void]] = [:]
-    private var eventQueue = PriorityQueue<ArkEvent>(sort: ArkEventManager.compareEventPriority)
+    private var listeners: [ArkEventID: [(any ArkEvent) -> Void]] = [:]
+    private var eventQueue = PriorityQueue<any ArkEvent>(sort: ArkEventManager.compareEventPriority)
 
-    func subscribe(to eventId: ArkEventID, listener: @escaping (ArkEvent) -> Void) {
+    func subscribe(to eventId: ArkEventID, _ listener: @escaping (any ArkEvent) -> Void) {
         if listeners[eventId] == nil {
             listeners[eventId] = []
         }
+        
         listeners[eventId]?.append(listener)
     }
 
-    func emit(_ event: inout ArkEvent) {
+    func emit<Event: ArkEvent>(_ event: inout Event) {
         event.timestamp = Date()
         eventQueue.enqueue(event)
     }
@@ -26,7 +27,7 @@ class ArkEventManager: ArkEventContext {
     func processEvents() {
         // If events generate more events, the new events will be processed in the next cycle
         var processingEventQueue = eventQueue
-        eventQueue = PriorityQueue<ArkEvent>(sort: ArkEventManager.compareEventPriority)
+        eventQueue = PriorityQueue<any ArkEvent>(sort: ArkEventManager.compareEventPriority)
         while !processingEventQueue.isEmpty {
             guard let event = processingEventQueue.dequeue() else {
                 fatalError("[ArkEventManager.processEvents()] dequeue failed: Expected event, found nil.")
@@ -43,7 +44,7 @@ class ArkEventManager: ArkEventContext {
         }
     }
 
-    private static func compareEventPriority(event1: ArkEvent, event2: ArkEvent) -> Bool {
+    private static func compareEventPriority(event1: any ArkEvent, event2: any ArkEvent) -> Bool {
         let priority1 = event1.priority ?? 0
         let priority2 = event2.priority ?? 0
 

--- a/ArkKit/ark-physics-kit/ArkPhysicsSystem.swift
+++ b/ArkKit/ark-physics-kit/ArkPhysicsSystem.swift
@@ -178,7 +178,7 @@ class ArkPhysicsSystem: System {
 
     // MARK: Handle Collision
     func handleCollision(between entityA: Entity, and entityB: Entity) {
-        var arkCollisionEvent: ArkEvent = ArkCollisionEvent(eventData: ArkCollisionEventData(name: "collision", entityA: entityA, entityB: entityB))
+        var arkCollisionEvent = ArkCollisionEvent(eventData: ArkCollisionEventData(name: "collision", entityA: entityA, entityB: entityB))
         self.eventManager.emit(&arkCollisionEvent)
     }
 }

--- a/ArkKit/ark-rules-kit/action/Action.swift
+++ b/ArkKit/ark-rules-kit/action/Action.swift
@@ -1,5 +1,8 @@
-protocol Action {
-    func execute<Event: ArkEvent>(_ event: Event,
-                                  eventContext: ArkEventContext,
-                                  ecsContext: ArkECSContext)
+protocol Action<Event> {
+    associatedtype Event = ArkEvent
+
+    func execute(_ event: Event,
+                 context: ArkActionContext)
 }
+
+typealias ActionCallback<Event: ArkEvent> = (Event, ArkActionContext) -> Void

--- a/ArkKit/ark-rules-kit/action/Forever.swift
+++ b/ArkKit/ark-rules-kit/action/Forever.swift
@@ -1,16 +1,18 @@
-struct Forever: Action {
-    private let callback: (any ArkEvent, ArkEventContext, ArkECSContext) -> Void
-    init(_ callback: @escaping (any ArkEvent, ArkEventContext, ArkECSContext) -> Void) {
+struct Forever<Event: ArkEvent>: Action {
+    private let callback: ActionCallback<Event>
+
+    init(_ callback: @escaping ActionCallback<Event>) {
         self.callback = callback
     }
-    func execute<Event: ArkEvent>(_ event: Event, eventContext: ArkEventContext, ecsContext: ArkECSContext) {
-        callback(event, eventContext, ecsContext)
+
+    func execute(_ event: Event, context: ArkActionContext) {
+        callback(event, context)
         let nextForever = self
-        eventContext.subscribe(to: Event.id) { (nextEvent: any ArkEvent) -> Void in
+        context.events.subscribe(to: Event.id) { nextEvent in
             guard let castedEvent = nextEvent as? Event else {
                 return
             }
-            nextForever.execute(castedEvent, eventContext: eventContext, ecsContext: ecsContext)
+            nextForever.execute(castedEvent, context: context)
         }
     }
 }

--- a/ArkKit/ark-rules-kit/action/Once.swift
+++ b/ArkKit/ark-rules-kit/action/Once.swift
@@ -1,9 +1,11 @@
-struct Once: Action {
-    private let callback: (ArkEvent, ArkEventContext, ArkECSContext) -> Void
-    init(_ callback: @escaping (ArkEvent, ArkEventContext, ArkECSContext) -> Void) {
+struct Once<Event: ArkEvent>: Action {
+    private let callback: ActionCallback<Event>
+    
+    init(_ callback: @escaping ActionCallback<Event>) {
         self.callback = callback
     }
-    func execute<Event: ArkEvent>(_ event: Event, eventContext: ArkEventContext, ecsContext: ArkECSContext) {
-        callback(event, eventContext, ecsContext)
+    
+    func execute(_ event: Event, context: ArkActionContext) {
+        callback(event, context)
     }
 }

--- a/ArkKit/ark-rules-kit/rule/Rule.swift
+++ b/ArkKit/ark-rules-kit/rule/Rule.swift
@@ -1,4 +1,11 @@
-struct Rule {
+protocol Rule {
+    associatedtype Event: ArkEvent
+
+    var event: ArkEventID { get }
+    var action: any Action<Event> { get }
+}
+
+struct ArkRule<Event: ArkEvent>: Rule {
     let event: ArkEventID
-    let action: Action
+    let action: any Action<Event>
 }

--- a/ArkKit/ark-state-kit/ArkState.swift
+++ b/ArkKit/ark-state-kit/ArkState.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-typealias ArkStateSetupFunction = (_: ArkECSContext, _: ArkEventContext) -> Void
+typealias ArkStateSetupDelegate = (ArkActionContext) -> Void
 
 class ArkState {
     private(set) var arkECS: ArkECS
@@ -23,7 +23,9 @@ class ArkState {
         eventManager.processEvents()
     }
 
-    func setup(_ setupFunction: ArkStateSetupFunction) {
-        setupFunction(arkECS, eventManager)
+    func setup(_ setupFunction: ArkStateSetupDelegate) {
+        let context = ArkActionContext(ecs: arkECS, events: eventManager)
+        
+        setupFunction(context)
     }
 }


### PR DESCRIPTION
- Make events generic so that the listeners don't have to typecast event and event data.
- Create ArkActionContext, which is a facade that wraps relevant contexts before passing to `.setup` and `.rule` handlers