### PR TITLE
[ark-render] refactor: make CanvasContext orchestrator

### DIFF
--- a/ArkKit/ark-game/view/ui-kit/ArkUIKitCanvasRenderer.swift
+++ b/ArkKit/ark-game/view/ui-kit/ArkUIKitCanvasRenderer.swift
@@ -27,68 +27,61 @@ class ArkUIKitCanvasRenderer: CanvasRenderer {
     }
 
     func render(_ circle: CircleRenderableComponent) -> any Renderable {
-        let renderable = UIKitCircle(radius: circle.radius, center: circle.center)
+        UIKitCircle(radius: circle.radius, center: circle.center)
             .rotate(by: circle.rotation)
             .zPosition(circle.zPosition)
             .setIsUserInteractionEnabled(circle.isUserInteractionEnabled)
             .applyModifiers(modifierInfo: circle, colorGetter: getColor)
-        renderable.render(into: getParentView(layer: circle.renderLayer))
-        return renderable
     }
 
     func render(_ rect: RectRenderableComponent) -> any Renderable {
-        let renderable = UIKitRect(width: rect.width, height: rect.height,
-                                   center: rect.center)
+        UIKitRect(width: rect.width, height: rect.height, center: rect.center)
             .rotate(by: rect.rotation)
             .zPosition(rect.zPosition)
             .setIsUserInteractionEnabled(rect.isUserInteractionEnabled)
             .applyModifiers(modifierInfo: rect, colorGetter: getColor)
-        renderable.render(into: getParentView(layer: rect.renderLayer))
-        return renderable
     }
 
     func render(_ polygon: PolygonRenderableComponent) -> any Renderable {
-        let renderable = UIKitPolygon(points: polygon.points, frame: polygon.frame)
+        UIKitPolygon(points: polygon.points, frame: polygon.frame)
             .rotate(by: polygon.rotation)
             .zPosition(polygon.zPosition)
             .setIsUserInteractionEnabled(polygon.isUserInteractionEnabled)
             .applyModifiers(modifierInfo: polygon, colorGetter: getColor)
-        renderable.render(into: getParentView(layer: polygon.renderLayer))
-        return renderable
     }
 
     func render(_ image: BitmapImageRenderableComponent) -> any Renderable {
-        let renderable = UIKitImageBitmap(imageResourcePath: image.imageResourcePath,
-                                          center: image.center,
-                                          width: image.width,
-                                          height: image.height)
-            .rotate(by: image.rotation)
-            .zPosition(image.zPosition)
-            .setIsUserInteractionEnabled(image.isUserInteractionEnabled)
-            .applyModifiers(modifierInfo: image)
-        renderable.render(into: getParentView(layer: image.renderLayer))
-        return renderable
+        UIKitImageBitmap(imageResourcePath: image.imageResourcePath,
+                         center: image.center,
+                         width: image.width,
+                         height: image.height)
+        .rotate(by: image.rotation)
+        .zPosition(image.zPosition)
+        .setIsUserInteractionEnabled(image.isUserInteractionEnabled)
+        .applyModifiers(modifierInfo: image)
     }
 
     func render(_ button: ButtonRenderableComponent) -> any Renderable {
-        let renderable = UIKitButton(width: button.width, height: button.height,
-                                     center: button.center)
+        UIKitButton(width: button.width, height: button.height, center: button.center)
             .rotate(by: button.rotation)
             .zPosition(button.zPosition)
             .setIsUserInteractionEnabled(button.isUserInteractionEnabled)
             .applyModifiers(modifierInfo: button)
-        renderable.render(into: getParentView(layer: button.renderLayer))
-        return renderable
     }
 
     func render(_ joystick: JoystickRenderableComponent) -> any Renderable {
-        let renderable = UIKitJoystick(center: joystick.center, radius: joystick.radius)
+        UIKitJoystick(center: joystick.center, radius: joystick.radius)
             .rotate(by: joystick.rotation)
             .zPosition(joystick.zPosition)
             .setIsUserInteractionEnabled(joystick.isUserInteractionEnabled)
             .applyModifiers(modifierInfo: joystick)
-        renderable.render(into: getParentView(layer: joystick.renderLayer))
-        return renderable
+    }
+
+    func upsertToView<T: Renderable>(_ renderable: T, at renderLayer: RenderLayer) {
+        guard let layer = getParentView(layer: renderLayer) as? T.Container else {
+            return
+        }
+        renderable.render(into: layer)
     }
 
     let defaultColor: UIColor = .black

--- a/ArkKit/ark-game/view/ui-kit/ArkUIKitViewController.swift
+++ b/ArkKit/ark-game/view/ui-kit/ArkUIKitViewController.swift
@@ -75,7 +75,6 @@ extension ArkUIKitViewController: GameStateRenderer {
 }
 
 extension ArkUIKitViewController: AbstractView {
-    typealias SomeRenderable = UIKitRenderable
     func didMove(to parent: any AbstractParentView) {
         guard let parentViewController = parent as? UIViewController else {
             return
@@ -86,11 +85,5 @@ extension ArkUIKitViewController: AbstractView {
         onRootViewResize { newSize in
             delegate(newSize)
         }
-    }
-    func addToSubview(_ renderable: any Renderable) {
-//        guard let uiView = renderable as? UIView else {
-//            return
-//        }
-//        self.view.addSubview(uiView)
     }
 }

--- a/ArkKit/ark-game/view/ui-kit/ArkUIKitViewController.swift
+++ b/ArkKit/ark-game/view/ui-kit/ArkUIKitViewController.swift
@@ -70,11 +70,12 @@ extension ArkUIKitViewController: GameStateRenderer {
         let canvasRenderer = ArkUIKitCanvasRenderer(rootView: self.view,
                                                     canvasView: canvasView,
                                                     canvasFrame: canvasContext.canvasFrame)
-        canvas.render(using: canvasRenderer, to: canvasContext)
+        canvasContext.render(canvas, using: canvasRenderer)
     }
 }
 
 extension ArkUIKitViewController: AbstractView {
+    typealias SomeRenderable = UIKitRenderable
     func didMove(to parent: any AbstractParentView) {
         guard let parentViewController = parent as? UIViewController else {
             return
@@ -85,5 +86,11 @@ extension ArkUIKitViewController: AbstractView {
         onRootViewResize { newSize in
             delegate(newSize)
         }
+    }
+    func addToSubview(_ renderable: any Renderable) {
+//        guard let uiView = renderable as? UIView else {
+//            return
+//        }
+//        self.view.addSubview(uiView)
     }
 }

--- a/ArkKit/ark-render-kit/ArkCanvas.swift
+++ b/ArkKit/ark-render-kit/ArkCanvas.swift
@@ -1,6 +1,6 @@
 struct ArkCanvas: Canvas {
-    var componentsToUnmount: [EntityID: [RenderableComponentType: (any Renderable)?]] = [:]
-    var componentsToMount: [EntityID: [RenderableComponentType: any RenderableComponent]] = [:]
+    private(set) var componentsToUnmount: [EntityID: [RenderableComponentType: (any Renderable)?]] = [:]
+    private(set) var componentsToMount: [EntityID: [RenderableComponentType: any RenderableComponent]] = [:]
 
     mutating func addComponentToUnmount(entityId: EntityID,
                                         componentType: RenderableComponentType,
@@ -20,32 +20,4 @@ struct ArkCanvas: Canvas {
             componentsToMount[entityId] = [componentType: renderableComponent]
         }
     }
-//    var canvasComponentsToRender: [(Entity, any RenderableComponent, any RenderableComponent.Type)] = []
-//    var canvasRenderablesToUnmount: [(Entity, any RenderableComponent.Type)] = []
-//
-//    func render(using renderer: any CanvasRenderer, to context: CanvasContext) {
-//        for (entity, canvasComponent, compType) in canvasComponentsToRender {
-//            if let (_, prevRenderable) = context.memo[entity]?[ObjectIdentifier(compType)] {
-//                prevRenderable.unmount()
-//            }
-//            let renderable = canvasComponent.render(using: renderer)
-//            context.saveToMemo(entity: entity, canvasComponentType: compType,
-//                               canvasComponent: canvasComponent, renderable: renderable)
-//        }
-//    }
-//
-//    func unmount(from context: CanvasContext) {
-//        for (entity, canvasComponentType) in canvasRenderablesToUnmount {
-//            let renderable = context.removeFromMemo(entity: entity, canvasComponentType: canvasComponentType)
-//            renderable?.unmount()
-//        }
-//    }
-//    mutating func addToRender(entity: Entity,
-//                              canvasComponent: any RenderableComponent,
-//                              compType: any RenderableComponent.Type) {
-//        canvasComponentsToRender.append((entity, canvasComponent, compType))
-//    }
-//    mutating func addToUnmount(entity: Entity, compType: any RenderableComponent.Type, context: CanvasContext) {
-//        canvasRenderablesToUnmount.append((entity, compType))
-//    }
 }

--- a/ArkKit/ark-render-kit/ArkCanvas.swift
+++ b/ArkKit/ark-render-kit/ArkCanvas.swift
@@ -1,30 +1,51 @@
 struct ArkCanvas: Canvas {
-    var canvasComponentsToRender: [(Entity, any RenderableComponent, any RenderableComponent.Type)] = []
-    var canvasRenderablesToUnmount: [(Entity, any RenderableComponent.Type)] = []
+    var componentsToUnmount: [EntityID: [RenderableComponentType: (any Renderable)?]] = [:]
+    var componentsToMount: [EntityID: [RenderableComponentType: any RenderableComponent]] = [:]
 
-    func render(using renderer: any CanvasRenderer, to context: CanvasContext) {
-        for (entity, canvasComponent, compType) in canvasComponentsToRender {
-            if let (_, prevRenderable) = context.memo[entity]?[ObjectIdentifier(compType)] {
-                prevRenderable.unmount()
-            }
-            let renderable = canvasComponent.render(using: renderer)
-            context.saveToMemo(entity: entity, canvasComponentType: compType,
-                               canvasComponent: canvasComponent, renderable: renderable)
+    mutating func addComponentToUnmount(entityId: EntityID,
+                                        componentType: RenderableComponentType,
+                                        renderable: (any Renderable)?) {
+        if componentsToUnmount[entityId] != nil {
+            componentsToUnmount[entityId]?[componentType] = renderable
+        } else {
+            componentsToUnmount[entityId] = [componentType: renderable]
         }
     }
-
-    func unmount(from context: CanvasContext) {
-        for (entity, canvasComponentType) in canvasRenderablesToUnmount {
-            let renderable = context.removeFromMemo(entity: entity, canvasComponentType: canvasComponentType)
-            renderable?.unmount()
+    mutating func addComponentToMount(entityId: EntityID,
+                                      componentType: RenderableComponentType,
+                                      renderableComponent: any RenderableComponent) {
+        if componentsToMount[entityId] != nil {
+            componentsToMount[entityId]?[componentType] = renderableComponent
+        } else {
+            componentsToMount[entityId] = [componentType: renderableComponent]
         }
     }
-    mutating func addToRender(entity: Entity,
-                              canvasComponent: any RenderableComponent,
-                              compType: any RenderableComponent.Type) {
-        canvasComponentsToRender.append((entity, canvasComponent, compType))
-    }
-    mutating func addToUnmount(entity: Entity, compType: any RenderableComponent.Type, context: CanvasContext) {
-        canvasRenderablesToUnmount.append((entity, compType))
-    }
+//    var canvasComponentsToRender: [(Entity, any RenderableComponent, any RenderableComponent.Type)] = []
+//    var canvasRenderablesToUnmount: [(Entity, any RenderableComponent.Type)] = []
+//
+//    func render(using renderer: any CanvasRenderer, to context: CanvasContext) {
+//        for (entity, canvasComponent, compType) in canvasComponentsToRender {
+//            if let (_, prevRenderable) = context.memo[entity]?[ObjectIdentifier(compType)] {
+//                prevRenderable.unmount()
+//            }
+//            let renderable = canvasComponent.render(using: renderer)
+//            context.saveToMemo(entity: entity, canvasComponentType: compType,
+//                               canvasComponent: canvasComponent, renderable: renderable)
+//        }
+//    }
+//
+//    func unmount(from context: CanvasContext) {
+//        for (entity, canvasComponentType) in canvasRenderablesToUnmount {
+//            let renderable = context.removeFromMemo(entity: entity, canvasComponentType: canvasComponentType)
+//            renderable?.unmount()
+//        }
+//    }
+//    mutating func addToRender(entity: Entity,
+//                              canvasComponent: any RenderableComponent,
+//                              compType: any RenderableComponent.Type) {
+//        canvasComponentsToRender.append((entity, canvasComponent, compType))
+//    }
+//    mutating func addToUnmount(entity: Entity, compType: any RenderableComponent.Type, context: CanvasContext) {
+//        canvasRenderablesToUnmount.append((entity, compType))
+//    }
 }

--- a/ArkKit/ark-render-kit/Canvas.swift
+++ b/ArkKit/ark-render-kit/Canvas.swift
@@ -19,6 +19,7 @@
  * ```
  */
 protocol Canvas {
-    func render(using renderer: any CanvasRenderer, to context: CanvasContext)
-    func unmount(from context: CanvasContext)
+    typealias RenderableComponentType = ObjectIdentifier
+    var componentsToUnmount: [EntityID: [RenderableComponentType: (any Renderable)?]] { get }
+    var componentsToMount: [EntityID: [RenderableComponentType: any RenderableComponent]] { get }
 }

--- a/ArkKit/ark-render-kit/CanvasRenderer.swift
+++ b/ArkKit/ark-render-kit/CanvasRenderer.swift
@@ -16,6 +16,8 @@ protocol CanvasRenderer {
     func render(_ image: BitmapImageRenderableComponent) -> any Renderable
     func render(_ button: ButtonRenderableComponent) -> any Renderable
     func render(_ joystick: JoystickRenderableComponent) -> any Renderable
+
+    func upsertToView<T: Renderable>(_ renderable: T, at renderLayer: RenderLayer)
 }
 
 extension CanvasRenderer {


### PR DESCRIPTION
### Key Changes
- Remove side effect from `ArkUIKitCanvasRenderer` in `render() -> any Renderable` method
- make `CanvasContext` the orchestrator that orchestrates the rendering of the `Canvas`
- reduce role of `Canvas` to basic storage of the componentsToMount and componentsToUnmount