### PR TITLE
[ark-rules] feat: add priority to rule action

### DIFF
--- a/ArkGameExample/TankGame/TankGameManager.swift
+++ b/ArkGameExample/TankGame/TankGameManager.swift
@@ -99,6 +99,11 @@ class TankGameManager {
             .on(TankMoveEvent.self) { event, context in
                 self.handleTankMove(event, in: context)
             }
+            .on(TankMoveEvent.self, chain: {_, _ in
+                print("first")
+            }, { _, _ in
+                print("last")
+            })
             .on(TankShootEvent.self) { event, context in
                 self.handleTankShoot(event, in: context)
             }

--- a/ArkKit/Ark.swift
+++ b/ArkKit/Ark.swift
@@ -68,8 +68,15 @@ class Ark {
     }
 
     private func setup(_ rules: [any Rule]) {
+        // sort the rules by priority before adding to eventContext
+        let sortedRules = rules.sorted(by: { x, y in
+            if x.event == y.event {
+                return x.action.priority < y.action.priority
+            }
+            return x.event < y.event
+        })
         // subscribe all rules to the eventManager
-        for rule in rules {
+        for rule in sortedRules {
             arkState.eventManager.subscribe(to: rule.event) { event in
                 event.executeAction(rule.action, context: self.actionContext)
             }

--- a/ArkKit/ArkBlueprint.swift
+++ b/ArkKit/ArkBlueprint.swift
@@ -31,4 +31,18 @@ struct ArkBlueprint {
         newSelf.rules = newRules
         return newSelf
     }
+
+    func on<Event: ArkEvent>(
+        _ eventType: Event.Type,
+        chain callbacks: ActionCallback<Event>...
+    ) -> Self {
+        var newRules = rules
+        for (i, callback) in callbacks.enumerated() {
+            let action = ArkAction(callback: callback, priority: i + 1)
+            newRules.append(ArkRule(event: Event.id, action: action))
+        }
+        var newSelf = self
+        newSelf.rules = newRules
+        return newSelf
+    }
 }

--- a/ArkKit/ark-rules-kit/action/Action.swift
+++ b/ArkKit/ark-rules-kit/action/Action.swift
@@ -1,5 +1,6 @@
 protocol Action<Event> {
     associatedtype Event: ArkEvent
+    var priority: Int { get }
 
     func execute(_ event: Event,
                  context: ArkActionContext)
@@ -7,7 +8,12 @@ protocol Action<Event> {
 
 struct ArkAction<Event: ArkEvent>: Action {
     let callback: ActionCallback<Event>
+    let priority: Int
 
+    init(callback: @escaping ActionCallback<Event>, priority: Int = 0) {
+        self.callback = callback
+        self.priority = priority
+    }
     func execute(_ event: Event,
                  context: ArkActionContext) {
         callback(event, context)


### PR DESCRIPTION
## Key Changes
- Add priority to `Action` so that the action callbacks are subscribed in order
- This is so that if there's a scenario where an event occurs and two actions are meant to occur (e.g. `on: TankShotEvent, then: TankDie`, `on: TankShotEvent, then: TankHpUpgrade`), the actions are executed by the priority of chain.
   - if equal priority, then the actions for the event can be executed in any order

## Example Usage
```swift
.on(TankMoveEvent.self, chain: {_, _ in
    print("first")
}, { _, _ in
    print("last")
})
```