### PR TITLE
[ark-event-kit] refactor: remove event mutation in event emitting

### DIFF
--- a/ArkGameExample/TankGame/Events/TankMoveEvent.swift
+++ b/ArkGameExample/TankGame/Events/TankMoveEvent.swift
@@ -17,7 +17,6 @@ struct TankMoveEventData: ArkEventData {
 struct TankMoveEvent: ArkEvent {
     static var id = UUID()
     var eventData: TankMoveEventData
-    var timestamp = Date()
     var priority: Int?
 
     init(eventData: TankMoveEventData, priority: Int? = nil) {

--- a/ArkGameExample/TankGame/Events/TankShootEvent.swift
+++ b/ArkGameExample/TankGame/Events/TankShootEvent.swift
@@ -15,7 +15,6 @@ struct TankShootEventData: ArkEventData {
 struct TankShootEvent: ArkEvent {
     static var id = UUID()
     var eventData: TankShootEventData
-    var timestamp = Date()
     var priority: Int?
 
     init(eventData: TankShootEventData, priority: Int? = nil) {

--- a/ArkGameExample/TankGame/TankGameEntityCreator.swift
+++ b/ArkGameExample/TankGame/TankGameEntityCreator.swift
@@ -48,20 +48,20 @@ enum TankGameEntityCreator {
                 .onPanStart { angle, mag in
                     let tankMoveEventData = TankMoveEventData(name: "TankMoveEvent", tankEntity: tankEntity,
                                                               angle: angle, magnitude: mag)
-                    var tankMoveEvent: any ArkEvent = TankMoveEvent(eventData: tankMoveEventData)
-                    eventContext.emit(&tankMoveEvent)
+                    let tankMoveEvent: any ArkEvent = TankMoveEvent(eventData: tankMoveEventData)
+                    eventContext.emit(tankMoveEvent)
                 }
                 .onPanChange { angle, mag in
                     let tankMoveEventData = TankMoveEventData(name: "TankMoveEvent", tankEntity: tankEntity,
                                                               angle: angle, magnitude: mag)
-                    var tankMoveEvent: any ArkEvent = TankMoveEvent(eventData: tankMoveEventData)
-                    eventContext.emit(&tankMoveEvent)
+                    let tankMoveEvent: any ArkEvent = TankMoveEvent(eventData: tankMoveEventData)
+                    eventContext.emit(tankMoveEvent)
                 }
                 .onPanEnd { _, _ in
                     let tankMoveEventData = TankMoveEventData(name: "TankMoveEvent", tankEntity: tankEntity,
                                                               angle: 0, magnitude: 0)
-                    var tankMoveEvent: any ArkEvent = TankMoveEvent(eventData: tankMoveEventData)
-                    eventContext.emit(&tankMoveEvent)
+                    let tankMoveEvent: any ArkEvent = TankMoveEvent(eventData: tankMoveEventData)
+                    eventContext.emit(tankMoveEvent)
                 }
         ])
     }
@@ -79,7 +79,7 @@ enum TankGameEntityCreator {
                 .onTap {
                     let tankShootEventData = TankShootEventData(name: "TankShootEvent", tankEntity: tankEntity)
                     var tankShootEvent: any ArkEvent = TankShootEvent(eventData: tankShootEventData)
-                    eventContext.emit(&tankShootEvent)
+                    eventContext.emit(tankShootEvent)
                 }
                 .label("Fire!", color: .blue)
                 .borderRadius(20)

--- a/ArkKit/ark-event-kit/ArkEvent.swift
+++ b/ArkKit/ark-event-kit/ArkEvent.swift
@@ -14,6 +14,5 @@ protocol ArkEvent<Data> {
 
     static var id: ArkEventID { get }
     var eventData: Data { get }
-    var timestamp: Date { get set }
     var priority: Int? { get set }
 }

--- a/ArkKit/ark-event-kit/ArkEventContext.swift
+++ b/ArkKit/ark-event-kit/ArkEventContext.swift
@@ -1,6 +1,6 @@
 protocol ArkEventContext {
     typealias EventListener = (any ArkEvent) -> Void
 
-    func emit<Event: ArkEvent>(_ event: inout Event)
+    func emit<Event: ArkEvent>(_ event: Event)
     func subscribe(to eventId: ArkEventID, _ listener: @escaping EventListener)
 }

--- a/ArkKit/ark-event-kit/DemoArkEvent.swift
+++ b/ArkKit/ark-event-kit/DemoArkEvent.swift
@@ -22,7 +22,6 @@ struct DemoArkEvent: ArkEvent {
 
     static var id = UUID()  // Unique identifier for the DemoArkEvent type.
     var eventData: ArkEventData?  // Optional event data.
-    var timestamp = Date()
     var priority: Int?
 
     /// Initializes a new DemoArkEvent with optional event data.
@@ -59,4 +58,4 @@ struct DemoArkEventTest {
 // let em = ArkEventManager()
 // let testEvent = DemoArkEvent(eventData: DemoArkEventData(name: "Hi", number: 4))
 // DemoArkEventTest.testSubscribe(em)
-// em.emit(&DemoArkEvent.id)
+// em.emit(DemoArkEvent.id)

--- a/ArkKit/ark-game/model/ArkGameModel.swift
+++ b/ArkKit/ark-game/model/ArkGameModel.swift
@@ -19,7 +19,7 @@ class ArkGameModel {
             newSize: size
         )
         var event = ScreenResizeEvent(eventData: eventData)
-        gameState?.eventManager.emit(&event)
+        gameState?.eventManager.emit(event)
     }
 
     func retrieveCanvas() -> Canvas? {

--- a/ArkKit/ark-physics-kit/ArkPhysicsSystem.swift
+++ b/ArkKit/ark-physics-kit/ArkPhysicsSystem.swift
@@ -167,12 +167,12 @@ class ArkPhysicsSystem: System {
     // MARK: Handle Collision
     func handleCollisionBegan(between entityA: Entity, and entityB: Entity) {
         var arkCollisionEvent = makeCollisionEvent(ArkCollisionBeganEvent.self, entityA, entityB)
-        self.eventManager.emit(&arkCollisionEvent)
+        self.eventManager.emit(arkCollisionEvent)
     }
 
     func handleCollisionEnd(between entityA: Entity, and entityB: Entity) {
         var arkCollisionEvent = makeCollisionEvent(ArkCollisionEndedEvent.self, entityA, entityB)
-        self.eventManager.emit(&arkCollisionEvent)
+        self.eventManager.emit(arkCollisionEvent)
     }
 
     private func makeCollisionEvent<T: ArkCollisionEventProtocol> (_ eventType: T.Type,
@@ -221,7 +221,6 @@ struct ArkCollisionEventData: ArkEventData {
 struct ArkCollisionEndedEvent: ArkCollisionEventProtocol {
     static var id = UUID()
     var eventData: ArkCollisionEventData
-    var timestamp = Date()
     var priority: Int?
 
     init(eventData: ArkCollisionEventData, priority: Int? = 10) {
@@ -232,7 +231,6 @@ struct ArkCollisionEndedEvent: ArkCollisionEventProtocol {
 struct ArkCollisionBeganEvent: ArkCollisionEventProtocol {
     static var id = UUID()
     var eventData: ArkCollisionEventData
-    var timestamp = Date()
     var priority: Int?
 
     init(eventData: ArkCollisionEventData, priority: Int? = 10) {

--- a/ArkKit/ark-render-kit/abstract/event/ScreenResizeEvent.swift
+++ b/ArkKit/ark-render-kit/abstract/event/ScreenResizeEvent.swift
@@ -10,6 +10,5 @@ struct ScreenResizeEvent: ArkEvent {
     static var id = UUID()
 
     var eventData: ScreenResizeEventData
-    var timestamp = Date()
     var priority: Int?
 }

--- a/ArkKitTests/ark-event-kit-tests/ArkEventKitTests.swift
+++ b/ArkKitTests/ark-event-kit-tests/ArkEventKitTests.swift
@@ -10,7 +10,6 @@ struct MockEventData: ArkEventData {
 struct EventStub: ArkEvent {
     static var id: ArkEventID = UUID()
     var eventData: ArkEventData
-    var timestamp = Date()
     var priority: Int?
 
     init(name: String = "MockEvent", priority: Int = 1) {
@@ -22,7 +21,6 @@ struct EventStub: ArkEvent {
 struct EventStub1: ArkEvent {
     static var id: ArkEventID = UUID()
     var eventData: ArkEventData
-    var timestamp = Date()
     var priority: Int?
 
     init(name: String = "MockEvent", priority: Int = 1) {
@@ -34,7 +32,6 @@ struct EventStub1: ArkEvent {
 struct EventStub2: ArkEvent {
     static var id: ArkEventID = UUID()
     var eventData: ArkEventData
-    var timestamp = Date()
     var priority: Int?
 
     init(name: String = "MockEvent", priority: Int = 1) {
@@ -66,7 +63,7 @@ class ArkEventKitTests: XCTestCase {
         }
 
         var event = EventStub()
-        eventManager.emit(&event)
+        eventManager.emit(event)
         eventManager.processEvents()
 
         waitForExpectations(timeout: 1) { error in
@@ -88,7 +85,7 @@ class ArkEventKitTests: XCTestCase {
         }
 
         var event = EventStub() // Default event
-        eventManager.emit(&event)
+        eventManager.emit(event)
         eventManager.processEvents()
 
         wait(for: [expectation1, expectation2], timeout: 1)
@@ -108,8 +105,8 @@ class ArkEventKitTests: XCTestCase {
             executionOrder.append(event.priority ?? 0)
         }
 
-        eventManager.emit(&highPriorityEvent)
-        eventManager.emit(&lowPriorityEvent)
+        eventManager.emit(highPriorityEvent)
+        eventManager.emit(lowPriorityEvent)
 
         XCTAssertEqual(executionOrder, [], "Array should be empty")
 
@@ -132,8 +129,8 @@ class ArkEventKitTests: XCTestCase {
             handledEventsNames.append("FirstEvent")
         }
 
-        eventManager.emit(&firstEvent)
-        eventManager.emit(&secondEvent)
+        eventManager.emit(firstEvent)
+        eventManager.emit(secondEvent)
         eventManager.processEvents()
 
         XCTAssertEqual(handledEventsNames, ["FirstEvent", "SecondEvent"],
@@ -150,7 +147,7 @@ class ArkEventKitTests: XCTestCase {
             modificationFlag = true
         }
 
-        eventManager.emit(&event)
+        eventManager.emit(event)
         eventManager.processEvents()
 
         XCTAssertTrue(modificationFlag, "The event listener should have been called and attempted a modification")
@@ -163,7 +160,7 @@ class ArkEventKitTests: XCTestCase {
 
         eventManager.subscribe(to: EventStub.id) { [weak self] _ in
             var newEvent = EventStub1(name: newEventName, priority: 2)
-            self?.eventManager.emit(&newEvent)
+            self?.eventManager.emit(newEvent)
         }
 
         var newEventTriggered = false
@@ -171,7 +168,7 @@ class ArkEventKitTests: XCTestCase {
             newEventTriggered = true
         }
 
-        eventManager.emit(&initialEvent)
+        eventManager.emit(initialEvent)
         eventManager.processEvents()
         eventManager.processEvents()
 

--- a/ArkKitTests/ark-rule-kit-tests/ArkRuleKitTests.swift
+++ b/ArkKitTests/ark-rule-kit-tests/ArkRuleKitTests.swift
@@ -59,10 +59,10 @@ class ArkRuleKitTests: XCTestCase {
             }
             forever.execute(event, context: actionContext)
         })
-        eventManager.emit(&eventStub)
+        eventManager.emit(eventStub)
         eventManager.processEvents()
         XCTAssertEqual(executedEvents.count, 1, "Callback should be called")
-        eventManager.emit(&eventStub)
+        eventManager.emit(eventStub)
         eventManager.processEvents()
         XCTAssertEqual(executedEvents.count, 2, "Callback should be called")
     }
@@ -87,10 +87,10 @@ class ArkRuleKitTests: XCTestCase {
             }
             once.execute(event, context: actionContext)
         })
-        eventManager.emit(&eventStub)
+        eventManager.emit(eventStub)
         eventManager.processEvents()
         XCTAssertEqual(executedEvents.count, 1, "Callback should be called")
-        eventManager.emit(&eventStub)
+        eventManager.emit(eventStub)
         eventManager.processEvents()
         XCTAssertEqual(executedEvents.count, 1, "Callback should be called")
     }

--- a/ArkKitTests/mocks/MockEventContext.swift
+++ b/ArkKitTests/mocks/MockEventContext.swift
@@ -1,7 +1,7 @@
 @testable import ArkKit
 
 class MockEventContext: ArkEventContext {
-    func emit<Event>(_ event: inout Event) where Event: ArkKit.ArkEvent {
+    func emit<Event>(_ event: Event) where Event: ArkKit.ArkEvent {
     }
 
     func subscribe(to eventId: ArkKit.ArkEventID, _ listener: @escaping EventListener) {


### PR DESCRIPTION
Remove event mutation when emitting an event.

`timestamp` removed from `ArkEvent`, event ordering by time will be done through `DatedEvent` instead.