### PR TITLE
[ark-ecs] feat: implement system lifecycle

### DIFF
--- a/ArkGameExample/TankGame/TankGameManager.swift
+++ b/ArkGameExample/TankGame/TankGameManager.swift
@@ -92,7 +92,10 @@ class TankGameManager {
     func setUpSystems() {
         blueprint = blueprint
             .forEachTick { deltaTime, _ in
-                print(deltaTime)
+                print("first one", deltaTime)
+            }
+            .forEachTick { deltaTime, _ in
+                print("second one", deltaTime)
             }
     }
 

--- a/ArkKit.xcodeproj/project.pbxproj
+++ b/ArkKit.xcodeproj/project.pbxproj
@@ -13,6 +13,10 @@
 		0230A48E2BB950AF001CFDAF /* OrderedDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0230A48D2BB950AF001CFDAF /* OrderedDictionary.swift */; };
 		0267BA1C2BBB05B70010F729 /* RuleTrigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0267BA1B2BBB05B70010F729 /* RuleTrigger.swift */; };
 		0267BA1E2BBB07D80010F729 /* ArkUpdateSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0267BA1D2BBB07D80010F729 /* ArkUpdateSystem.swift */; };
+		0267BA232BBD0F940010F729 /* SystemRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0267BA222BBD0F940010F729 /* SystemRunner.swift */; };
+		0267BA262BBD0FE00010F729 /* StartUpSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0267BA252BBD0FE00010F729 /* StartUpSystem.swift */; };
+		0267BA282BBD0FF00010F729 /* UpdateSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0267BA272BBD0FF00010F729 /* UpdateSystem.swift */; };
+		0267BA2A2BBD10060010F729 /* CleanUpSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0267BA292BBD10060010F729 /* CleanUpSystem.swift */; };
 		02A438262BB007C9000135BC /* ArkRuleKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A438252BB007C9000135BC /* ArkRuleKitTests.swift */; };
 		02A438292BB00D2B000135BC /* MockAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A438282BB00D2B000135BC /* MockAction.swift */; };
 		02A4382B2BB00D4D000135BC /* MockECSContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A4382A2BB00D4D000135BC /* MockECSContext.swift */; };
@@ -200,6 +204,10 @@
 		0230A48D2BB950AF001CFDAF /* OrderedDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderedDictionary.swift; sourceTree = "<group>"; };
 		0267BA1B2BBB05B70010F729 /* RuleTrigger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleTrigger.swift; sourceTree = "<group>"; };
 		0267BA1D2BBB07D80010F729 /* ArkUpdateSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArkUpdateSystem.swift; sourceTree = "<group>"; };
+		0267BA222BBD0F940010F729 /* SystemRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemRunner.swift; sourceTree = "<group>"; };
+		0267BA252BBD0FE00010F729 /* StartUpSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartUpSystem.swift; sourceTree = "<group>"; };
+		0267BA272BBD0FF00010F729 /* UpdateSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateSystem.swift; sourceTree = "<group>"; };
+		0267BA292BBD10060010F729 /* CleanUpSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanUpSystem.swift; sourceTree = "<group>"; };
 		02A438252BB007C9000135BC /* ArkRuleKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArkRuleKitTests.swift; sourceTree = "<group>"; };
 		02A438282BB00D2B000135BC /* MockAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAction.swift; sourceTree = "<group>"; };
 		02A4382A2BB00D4D000135BC /* MockECSContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockECSContext.swift; sourceTree = "<group>"; };
@@ -406,6 +414,18 @@
 				02E0E8EA2BA280890043E2BA /* view-components */,
 			);
 			path = "ark-uikit-lib";
+			sourceTree = "<group>";
+		};
+		0267BA242BBD0FC70010F729 /* system */ = {
+			isa = PBXGroup;
+			children = (
+				AD787A852B9C6C91003EBBD0 /* System.swift */,
+				0267BA252BBD0FE00010F729 /* StartUpSystem.swift */,
+				0267BA272BBD0FF00010F729 /* UpdateSystem.swift */,
+				0267BA292BBD10060010F729 /* CleanUpSystem.swift */,
+				0267BA222BBD0F940010F729 /* SystemRunner.swift */,
+			);
+			path = system;
 			sourceTree = "<group>";
 		};
 		02A438242BB007B1000135BC /* ark-rule-kit-tests */ = {
@@ -1002,9 +1022,9 @@
 			children = (
 				AD787A812B9C6BD9003EBBD0 /* Entity.swift */,
 				AD787A832B9C6C78003EBBD0 /* Component.swift */,
+				0267BA242BBD0FC70010F729 /* system */,
 				28A032DD2BAD4ED200851BFF /* InternalSystems */,
 				280CD3DA2BA8044600372C5D /* InternalComponents */,
-				AD787A852B9C6C91003EBBD0 /* System.swift */,
 				AD787A872B9C6D3A003EBBD0 /* EntityManager.swift */,
 				AD787A8B2B9C70FC003EBBD0 /* SystemManager.swift */,
 				AD6E03602B9F15FA00974EBF /* ArkECS.swift */,
@@ -1277,6 +1297,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0267BA282BBD0FF00010F729 /* UpdateSystem.swift in Sources */,
 				280CD3CE2BA74E4300372C5D /* BaseSKPhysicsScene.swift in Sources */,
 				280CD3C42BA7419400372C5D /* ArkPhysicsContactUpdateDelegate.swift in Sources */,
 				02C3950F2BA611B80075F1CA /* ArkEventContext.swift in Sources */,
@@ -1285,11 +1306,13 @@
 				0230A4862BB7F300001CFDAF /* ArkView.swift in Sources */,
 				945F7F932BA8861300933629 /* AbstractTappable.swift in Sources */,
 				02C394F72BA4428A0075F1CA /* UIKitJoystick.swift in Sources */,
+				0267BA262BBD0FE00010F729 /* StartUpSystem.swift in Sources */,
 				280CD3C82BA743D900372C5D /* AbstractArkPhysicsBody.swift in Sources */,
 				02C395242BA849B40075F1CA /* JoystickRenderableComponent.swift in Sources */,
 				942A16792BADF40600F0186B /* ArkAudioPlayer.swift in Sources */,
 				AD787A822B9C6BD9003EBBD0 /* Entity.swift in Sources */,
 				9479A3B42BA95E7E00F99013 /* AbstractColor.swift in Sources */,
+				0267BA2A2BBD10060010F729 /* CleanUpSystem.swift in Sources */,
 				280CD3B92BA7391700372C5D /* PhysicsComponent.swift in Sources */,
 				02E0E8F62BA283940043E2BA /* UIKitPolygon.swift in Sources */,
 				280CD3DE2BA8045200372C5D /* RotationComponent.swift in Sources */,
@@ -1374,6 +1397,7 @@
 				02C395222BA849700075F1CA /* PolygonRenderableComponent.swift in Sources */,
 				9479A3B12BA953D800F99013 /* ShapeRenderableComponent.swift in Sources */,
 				02C395012BA5A2BE0075F1CA /* Action.swift in Sources */,
+				0267BA232BBD0F940010F729 /* SystemRunner.swift in Sources */,
 				02C394E02BA405C10075F1CA /* Canvas.swift in Sources */,
 				942A16772BADF3ED00F0186B /* AudioContext.swift in Sources */,
 				AD787A842B9C6C78003EBBD0 /* Component.swift in Sources */,

--- a/ArkKit/Ark.swift
+++ b/ArkKit/Ark.swift
@@ -119,7 +119,7 @@ class Ark {
                 continue
             }
             let system = ArkUpdateSystem(action: action, context: self.actionContext)
-            arkState.arkECS.addSystem(system)
+            arkState.arkECS.addSystem(system, schedule: .update, isUnique: false)
         }
     }
 

--- a/ArkKit/ark-animation-kit/ArkAnimationSystem.swift
+++ b/ArkKit/ark-animation-kit/ArkAnimationSystem.swift
@@ -3,7 +3,7 @@ import Foundation
 /**
  *  A system which updates all running animation instances in ArkECS after the given delta.
  */
-class ArkAnimationSystem: System {
+class ArkAnimationSystem: UpdateSystem {
     var active: Bool
 
     init(active: Bool = true) {

--- a/ArkKit/ark-game/model/ArkGameModel.swift
+++ b/ArkKit/ark-game/model/ArkGameModel.swift
@@ -7,6 +7,7 @@ class ArkGameModel {
     init(gameState: ArkState, canvasContext: CanvasContext) {
         self.gameState = gameState
         self.canvasContext = canvasContext
+        self.gameState?.start()
     }
 
     func updateState(dt: Double) {
@@ -18,7 +19,7 @@ class ArkGameModel {
             name: "DisplayUpdateEvent",
             newSize: size
         )
-        var event = ScreenResizeEvent(eventData: eventData)
+        let event = ScreenResizeEvent(eventData: eventData)
         gameState?.eventManager.emit(event)
     }
 

--- a/ArkKit/ark-physics-kit/ArkPhysicsSystem.swift
+++ b/ArkKit/ark-physics-kit/ArkPhysicsSystem.swift
@@ -3,7 +3,7 @@ import Foundation
 /**
  *  A system which updates all running animation instances in ArkECS after the given delta.
  */
-class ArkPhysicsSystem: System {
+class ArkPhysicsSystem: UpdateSystem {
     var active: Bool
     var simulator: AbstractPhysicsArkSimulator
     var scene: AbstractArkPhysicsScene?

--- a/ArkKit/ark-render-kit/ArkCanvasSystem.swift
+++ b/ArkKit/ark-render-kit/ArkCanvasSystem.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-class ArkCanvasSystem: System {
+class ArkCanvasSystem: UpdateSystem {
     var active: Bool
     static let canvasComponentTypes: [any RenderableComponent.Type] = [
         ButtonRenderableComponent.self,

--- a/ArkKit/ark-state-kit/ArkState.swift
+++ b/ArkKit/ark-state-kit/ArkState.swift
@@ -11,9 +11,17 @@ class ArkState {
         self.eventManager = eventManager
     }
 
+    func start() {
+        arkECS.startup()
+    }
+
     func update(deltaTime: TimeInterval) {
         eventManager.processEvents()
         arkECS.update(deltaTime: deltaTime)
+    }
+
+    func finish() {
+        arkECS.cleanup()
     }
 
     func setup(_ setupDelegate: ArkStateSetupDelegate, displayContext: ArkDisplayContext) {

--- a/ArkKit/ark-state-kit/ark-ecs-kit/ArkECS.swift
+++ b/ArkKit/ark-state-kit/ark-ecs-kit/ArkECS.swift
@@ -53,7 +53,7 @@ extension ArkECS: ArkECSContext {
         entityManager.getComponents(from: entity)
     }
 
-    func addSystem(_ system: System) {
-        systemManager.add(system)
+    func addSystem(_ system: UpdateSystem, schedule: Schedule = .update, isUnique: Bool = true) {
+        systemManager.add(system, schedule: schedule, isUnique: isUnique)
     }
 }

--- a/ArkKit/ark-state-kit/ark-ecs-kit/ArkECS.swift
+++ b/ArkKit/ark-state-kit/ark-ecs-kit/ArkECS.swift
@@ -9,8 +9,16 @@ class ArkECS {
         self.systemManager = SystemManager()
     }
 
+    func startup() {
+        self.systemManager.startup()
+    }
+
     func update(deltaTime: TimeInterval) {
         systemManager.update(deltaTime: deltaTime, arkECS: self)
+    }
+
+    func cleanup() {
+        self.systemManager.finish()
     }
 }
 

--- a/ArkKit/ark-state-kit/ark-ecs-kit/InternalSystems/ArkTimeSystem.swift
+++ b/ArkKit/ark-state-kit/ark-ecs-kit/InternalSystems/ArkTimeSystem.swift
@@ -3,7 +3,7 @@ import Foundation
 /**
  *  A system which updates a StopWatchComponent instances in ArkECS after the given delta.
  */
-class ArkTimeSystem: System {
+class ArkTimeSystem: UpdateSystem {
     static let ARK_WORLD_TIME = "_ArkWorldTime"
 
     var active: Bool

--- a/ArkKit/ark-state-kit/ark-ecs-kit/InternalSystems/ArkUpdateSystem.swift
+++ b/ArkKit/ark-state-kit/ark-ecs-kit/InternalSystems/ArkUpdateSystem.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-class ArkUpdateSystem: System {
+class ArkUpdateSystem: UpdateSystem {
     var active: Bool
     let action: any Action<TimeInterval>
     let context: ArkActionContext

--- a/ArkKit/ark-state-kit/ark-ecs-kit/SystemManager.swift
+++ b/ArkKit/ark-state-kit/ark-ecs-kit/SystemManager.swift
@@ -27,7 +27,7 @@ class SystemManager {
 
     private(set) var uniqueSystemsByType = Set<SystemType>()
 
-    func add(_ system: UpdateSystem, schedule: Schedule = .update, isUnique: Bool = true) {
+    func add(_ system: System, schedule: Schedule = .update, isUnique: Bool = true) {
         let identifier = ObjectIdentifier(type(of: system))
 
         if isUnique {
@@ -47,14 +47,14 @@ class SystemManager {
         systemsBySchedule[schedule]?[identifier]?.append(system)
     }
 
-    func remove<T: UpdateSystem>(ofType type: T.Type) {
+    func remove<T: System>(ofType type: T.Type) {
         let identifier = ObjectIdentifier(type)
         for schedule in systemsBySchedule.keys {
             systemsBySchedule[schedule]?.removeValue(forKey: identifier)
         }
     }
 
-    func system<T: UpdateSystem>(ofType type: T.Type) -> [T] {
+    func system<T: System>(ofType type: T.Type) -> [T] {
         let identifier = ObjectIdentifier(type)
         return systemsBySchedule.flatMap { _, systemsMapping in
             systemsMapping[identifier]?.compactMap({ system in system as? T }) ?? []

--- a/ArkKit/ark-state-kit/ark-ecs-kit/SystemManager.swift
+++ b/ArkKit/ark-state-kit/ark-ecs-kit/SystemManager.swift
@@ -7,14 +7,26 @@
 
 import Foundation
 
+/**
+ * `Schedule` represents the lifecycle of systems
+ */
+enum Schedule {
+    case startup
+    case update
+    case finish
+}
+
 class SystemManager {
     typealias SystemType = ObjectIdentifier
 
-    private(set) var systems: OrderedDictionary<SystemType, System> = OrderedDictionary()
+    private(set) var systems: OrderedDictionary<SystemType, [System]> = OrderedDictionary()
 
     func add(_ system: System) {
         let identifier = ObjectIdentifier(type(of: system))
-        systems[identifier] = system
+        if systems[identifier] == nil {
+            systems[identifier] = []
+        }
+        systems[identifier]?.append(system)
     }
 
     func remove<T: System>(ofType type: T.Type) {
@@ -22,14 +34,16 @@ class SystemManager {
         systems.removeValue(forKey: identifier)
     }
 
-    func system<T: System>(ofType type: T.Type) -> T? {
+    func system<T: System>(ofType type: T.Type) -> [T] {
         let identifier = ObjectIdentifier(type)
-        return systems[identifier] as? T
+        return systems[identifier]?.compactMap({ system in  system as? T }) ?? []
     }
 
     func update(deltaTime: TimeInterval, arkECS: ArkECS) {
-        for (_, system) in systems {
-            system.update(deltaTime: deltaTime, arkECS: arkECS)
+        for (_, systemsPerType) in systems {
+            for system in systemsPerType {
+                system.update(deltaTime: deltaTime, arkECS: arkECS)
+            }
         }
     }
 

--- a/ArkKit/ark-state-kit/ark-ecs-kit/system/CleanUpSystem.swift
+++ b/ArkKit/ark-state-kit/ark-ecs-kit/system/CleanUpSystem.swift
@@ -1,0 +1,9 @@
+protocol CleanUpSystem: System {
+    func cleanup()
+}
+
+extension CleanUpSystem {
+    func run(using runner: SystemRunner) {
+        runner.run(self)
+    }
+}

--- a/ArkKit/ark-state-kit/ark-ecs-kit/system/StartUpSystem.swift
+++ b/ArkKit/ark-state-kit/ark-ecs-kit/system/StartUpSystem.swift
@@ -1,0 +1,9 @@
+protocol StartUpSystem: System {
+    func startup()
+}
+
+extension StartUpSystem {
+    func run(using runner: SystemRunner) {
+        runner.run(self)
+    }
+}

--- a/ArkKit/ark-state-kit/ark-ecs-kit/system/System.swift
+++ b/ArkKit/ark-state-kit/ark-ecs-kit/system/System.swift
@@ -9,6 +9,5 @@ import Foundation
 
 protocol System: AnyObject {
     var active: Bool { get set }
-
-    func update(deltaTime: TimeInterval, arkECS: ArkECS)
+    func run(using runner: SystemRunner)
 }

--- a/ArkKit/ark-state-kit/ark-ecs-kit/system/SystemRunner.swift
+++ b/ArkKit/ark-state-kit/ark-ecs-kit/system/SystemRunner.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/**
+ * Runs each different `System` using the Visitor / Double-dispatch pattern
+ */
+protocol SystemRunner {
+    func run(_ system: StartUpSystem)
+    func run(_ system: UpdateSystem)
+    func run(_ system: CleanUpSystem)
+}
+
+struct ArkSystemRunner: SystemRunner {
+    var deltaTime: TimeInterval?
+    var arkECS: ArkECS?
+
+    func run(_ system: any StartUpSystem) {
+        system.startup()
+    }
+
+    func run(_ system: any UpdateSystem) {
+        guard let dt = deltaTime, let ecs = arkECS else {
+            return
+        }
+        system.update(deltaTime: dt, arkECS: ecs)
+    }
+
+    func run(_ system: any CleanUpSystem) {
+        system.cleanup()
+    }
+}

--- a/ArkKit/ark-state-kit/ark-ecs-kit/system/UpdateSystem.swift
+++ b/ArkKit/ark-state-kit/ark-ecs-kit/system/UpdateSystem.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+protocol UpdateSystem: System {
+    func update(deltaTime: TimeInterval, arkECS: ArkECS)
+}
+
+extension UpdateSystem {
+    func run(using runner: SystemRunner) {
+        runner.run(self)
+    }
+}

--- a/ArkKitTests/ark-state-kit-tests/ark-ecs-kit-tests/SystemManagerTests.swift
+++ b/ArkKitTests/ark-state-kit-tests/ark-ecs-kit-tests/SystemManagerTests.swift
@@ -26,8 +26,8 @@ class SystemManagerTests: XCTestCase {
 
         systemManager.add(testSystem)
 
-        let retrievedSystem: MockSystem? = systemManager.system(ofType: MockSystem.self)
-        XCTAssertNotNil(retrievedSystem, "System should be added to the manager.")
+        let retrievedSystem: [MockSystem] = systemManager.system(ofType: MockSystem.self)
+        XCTAssertGreaterThan(retrievedSystem.count, 0, "System should be added to the manager.")
     }
 
     func testRemoveSystemRemovesSystem() {
@@ -37,8 +37,8 @@ class SystemManagerTests: XCTestCase {
 
         systemManager.remove(ofType: MockSystem.self)
 
-        let retrievedSystem: MockSystem? = systemManager.system(ofType: MockSystem.self)
-        XCTAssertNil(retrievedSystem, "System should be removed from the manager.")
+        let retrievedSystems: [MockSystem] = systemManager.system(ofType: MockSystem.self)
+        XCTAssertEqual(retrievedSystems.count, 0, "System should be removed from the manager.")
     }
 
     func testSystemReturnsCorrectSystem() {
@@ -46,9 +46,9 @@ class SystemManagerTests: XCTestCase {
         let testSystem = MockSystem()  // Assuming MockSystem conforms to your System protocol
         systemManager.add(testSystem)
 
-        let retrievedSystem: MockSystem? = systemManager.system(ofType: MockSystem.self)
+        let retrievedSystem: [MockSystem] = systemManager.system(ofType: MockSystem.self)
 
-        XCTAssertNotNil(retrievedSystem, "The correct system should be retrieved.")
+        XCTAssertEqual(retrievedSystem.count, 1, "The correct system should be retrieved.")
     }
 
     func testUpdateCallsUpdateOnAllSystems() {

--- a/ArkKitTests/ark-state-kit-tests/ark-ecs-kit-tests/SystemManagerTests.swift
+++ b/ArkKitTests/ark-state-kit-tests/ark-ecs-kit-tests/SystemManagerTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 class SystemManagerTests: XCTestCase {
 
-    class MockSystem: System {
+    class MockSystem: UpdateSystem {
         var active = true
 
         private(set) var updateCalled = false
@@ -27,7 +27,7 @@ class SystemManagerTests: XCTestCase {
         systemManager.add(testSystem)
 
         let retrievedSystem: [MockSystem] = systemManager.system(ofType: MockSystem.self)
-        XCTAssertGreaterThan(retrievedSystem.count, 0, "System should be added to the manager.")
+        XCTAssertEqual(retrievedSystem.count, 1, "System should be added to the manager.")
     }
 
     func testRemoveSystemRemovesSystem() {
@@ -46,9 +46,9 @@ class SystemManagerTests: XCTestCase {
         let testSystem = MockSystem()  // Assuming MockSystem conforms to your System protocol
         systemManager.add(testSystem)
 
-        let retrievedSystem: [MockSystem] = systemManager.system(ofType: MockSystem.self)
+        let retrievedSystems: [MockSystem] = systemManager.system(ofType: MockSystem.self)
 
-        XCTAssertEqual(retrievedSystem.count, 1, "The correct system should be retrieved.")
+        XCTAssertEqual(retrievedSystems.count, 1, "The correct system should be retrieved.")
     }
 
     func testUpdateCallsUpdateOnAllSystems() {

--- a/ArkKitTests/mocks/MockECSContext.swift
+++ b/ArkKitTests/mocks/MockECSContext.swift
@@ -31,6 +31,6 @@ class MockECSContext: ArkECSContext {
         nil
     }
 
-    func addSystem(_ system: any ArkKit.System) {
+    func addSystem(_ system: any ArkKit.UpdateSystem) {
     }
 }


### PR DESCRIPTION
## Key Changes

- Adds Lifecycle to Systems
- `StartUpSystem` will only run **once**

**Note**: i haven't figured out how we can call `.finish()` to trigger the `CleanUpSystem`, but ideally it should also only run once

@chownces can take a look and consider for audio preloading issues?
> - i think for audio that is inputted into the blueprint, under the hood can:
> 1. add to an `AudioPreloadSystem: StartUpSystem` and preload the audio
> 2. then the `audio.play()` can still be via event
> 3. then we can trigger `AudioUnloadSystem: CleanUpSystem` when the audio is meant to disperse