### PR TITLE
[ark-game] refactor: remove dependency on cameraContext in view

### DIFF
--- a/ArkKit/ark-game/coordinator/ArkGameCoordinator.swift
+++ b/ArkKit/ark-game/coordinator/ArkGameCoordinator.swift
@@ -28,8 +28,11 @@ class ArkGameCoordinator<View> {
         }
         let canvasContext = ArkCanvasContext(ecs: arkState.arkECS,
                                              arkView: arkView)
+        let cameraContext = ArkCameraContext(ecs: arkState.arkECS,
+                                             displayContext: displayContext)
         let arkGameModel = ArkGameModel(gameState: arkState,
-                                        canvasContext: canvasContext)
+                                        canvasContext: canvasContext,
+                                        cameraContext: cameraContext)
         let arkViewModel = ArkViewModel(gameModel: arkGameModel)
 
         // inject dependencies between M, V, VM
@@ -40,8 +43,6 @@ class ArkGameCoordinator<View> {
         // inject dependencies between game loop and view
         arkView.gameLoop = gameLoop
         gameLoop.updateGameWorldDelegate = arkView
-        arkView.cameraContext = ArkCameraContext(ecs: arkState.arkECS,
-                                                 displayContext: displayContext)
 
         // push view-controller to rootView
         rootView.pushView(arkView, animated: false)

--- a/ArkKit/ark-game/model/ArkGameModel.swift
+++ b/ArkKit/ark-game/model/ArkGameModel.swift
@@ -3,10 +3,14 @@ import Foundation
 class ArkGameModel<T> {
     var gameState: ArkState?
     var canvasContext: (any CanvasContext<T>)?
+    var cameraContext: (any CameraContext)?
 
-    init(gameState: ArkState, canvasContext: any CanvasContext<T>) {
+    init(gameState: ArkState,
+         canvasContext: any CanvasContext<T>,
+         cameraContext: CameraContext) {
         self.gameState = gameState
         self.canvasContext = canvasContext
+        self.cameraContext = cameraContext
         self.gameState?.startUp()
     }
 

--- a/ArkKit/ark-game/view-model/ArkViewModel.swift
+++ b/ArkKit/ark-game/view-model/ArkViewModel.swift
@@ -20,7 +20,8 @@ class ArkViewModel<T> {
             guard let currentCanvas = canvas, let canvasContext = gameModel.canvasContext else {
                 return
             }
-            viewRendererDelegate?.render(flatCanvas: currentCanvas, with: canvasContext)
+            let canvasToRender = gameModel.cameraContext?.transform(currentCanvas) ?? currentCanvas
+            viewRendererDelegate?.render(canvasToRender, with: canvasContext)
         }
     }
 

--- a/ArkKit/ark-game/view/ui-kit/ArkUIKitView.swift
+++ b/ArkKit/ark-game/view/ui-kit/ArkUIKitView.swift
@@ -10,7 +10,6 @@ class ArkUIKitView<T>: UIViewController, GameLoopable {
     var rootViewResizeDelegate: ScreenResizeDelegate?
     var cachedScreenSize: CGSize?
     var renderableBuilder: (any RenderableBuilder<UIView>)?
-    var cameraContext: CameraContext?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -42,13 +41,9 @@ class ArkUIKitView<T>: UIViewController, GameLoopable {
 }
 
 extension ArkUIKitView: GameStateRenderer {
-    func render(flatCanvas: Canvas, with canvasContext: any CanvasContext<UIView>) {
+    func render(_ canvas: Canvas, with canvasContext: any CanvasContext<UIView>) {
         let renderableBuilder = renderableBuilder ?? ArkUIKitRenderableBuilder()
-
-        // this canvas transform og canvas into mega canvas (Screen + Camera)
-        let canvasToRender = cameraContext?.transform(flatCanvas) ?? flatCanvas
-        // n camera containers + one screen container
-        canvasContext.render(canvasToRender, using: renderableBuilder)
+        canvasContext.render(canvas, using: renderableBuilder)
     }
 }
 

--- a/ArkKit/ark-render-kit/CanvasContext.swift
+++ b/ArkKit/ark-render-kit/CanvasContext.swift
@@ -4,7 +4,7 @@ protocol CanvasContext<View> {
     associatedtype View
     typealias RenderableComponentType = ObjectIdentifier
 
-    var arkView: any ArkView<View> { get }
+    var arkView: (any ArkView<View>)? { get }
     var memo: [EntityID: [RenderableComponentType: (any RenderableComponent, any Renderable)]] { get }
 
     func getFlatCanvas() -> ArkFlatCanvas
@@ -13,7 +13,7 @@ protocol CanvasContext<View> {
 
 class ArkCanvasContext<View>: CanvasContext {
     private(set) var memo: [EntityID: [RenderableComponentType: (any RenderableComponent, any Renderable)]] = [:]
-    private(set) var arkView: any ArkView<View>
+    private(set) weak var arkView: (any ArkView<View>)?
     private let ecs: ArkECS
 
     init(ecs: ArkECS, arkView: any ArkView<View>) {
@@ -81,6 +81,9 @@ class ArkCanvasContext<View>: CanvasContext {
     }
 
     private func render(_ renderable: any Renderable<View>) {
+        guard let arkView = arkView else {
+            return
+        }
         renderable.render(into: arkView.abstractView)
     }
 }

--- a/ArkKit/ark-render-kit/GameStateRenderer.swift
+++ b/ArkKit/ark-render-kit/GameStateRenderer.swift
@@ -9,6 +9,5 @@ import Foundation
  */
 protocol GameStateRenderer<View>: AnyObject {
     associatedtype View
-    var cameraContext: CameraContext? { get set }
-    func render(flatCanvas: Canvas, with canvasContext: any CanvasContext<View>)
+    func render(_ canvas: Canvas, with canvasContext: any CanvasContext<View>)
 }


### PR DESCRIPTION
as title.

Fixes:
- The CameraContext was placed in view, but should better be in Model so view does not have any model dependencies.
- The `arkView` was strongly referenced in `canvasContext`, but updated to weak reference to prevent strong cycles.