### PR TITLE
[tank-games] feat: add resize screen handlers to tank game demos

### DIFF
--- a/ArkGameExample/SceneDelegate.swift
+++ b/ArkGameExample/SceneDelegate.swift
@@ -19,6 +19,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window.makeKeyAndVisible()
 //        let arkBlueprint = defineArkBlueprint()
 //        let tankGameManager = TankGameManager(frameWidth: 820, frameHeight: 1_180)
+//        loadArkBlueprintToScene(tankGameManager.blueprint, window: window)
+
         let tankRaceGame = TankRaceGame()
         tankRaceGame.load()
         loadArkBlueprintToScene(tankRaceGame.blueprint, window: window)

--- a/ArkGameExample/TankGame/TankGameManager.swift
+++ b/ArkGameExample/TankGame/TankGameManager.swift
@@ -258,6 +258,17 @@ extension TankGameManager {
                 position: CGPoint(x: screenWidth * 1 / 6, y: screenHeight * 1 / 8))
             ecs.upsertComponent(positionComponent, to: shootButton2Entity)
         }
+
+        if let camEntity = ecs.getEntities(with: [PlacedCameraComponent.self]).first {
+            if let placedCameraComponent = ecs.getComponent(ofType: PlacedCameraComponent.self, for: camEntity) {
+                let updatedPlacedCameraComponent = PlacedCameraComponent(
+                    camera: placedCameraComponent.camera,
+                    screenPosition: CGPoint(x: screenWidth / 2, y: screenHeight / 2),
+                    size: screenSize
+                )
+                ecs.upsertComponent(updatedPlacedCameraComponent, to: camEntity)
+            }
+        }
     }
 
     private func handleTankMove(_ event: TankMoveEvent, in context: ArkActionContext<TankGameSounds>) {

--- a/ArkGameExample/TankRaceGame/TankRaceGame.swift
+++ b/ArkGameExample/TankRaceGame/TankRaceGame.swift
@@ -2,6 +2,13 @@ import Foundation
 
 class TankRaceGame {
     private(set) var blueprint = ArkBlueprintWithoutSound(frameWidth: 900, frameHeight: 10_000)
+    var joystick1: EntityID?
+    var joystick2: EntityID?
+    var joystick3: EntityID?
+    var camera1: Entity?
+    var camera2: Entity?
+    var camera3: Entity?
+
     private var tankIdEntityMap = [Int: Entity]()
 
     func load() {
@@ -69,27 +76,36 @@ class TankRaceGame {
                 size: CGSize(width: screenWidth / 3, height: screenHeight)
             ), to: tank3)
 
-            TankGameEntityCreator.createJoyStick(
+            let joystick1 = TankGameEntityCreator.createJoyStick(
                 center: CGPoint(x: screenWidth * 1 / 12, y: screenHeight * 7 / 8),
                 tankId: 1,
                 in: ecs,
                 eventContext: events,
                 zPosition: 999)
-            TankGameEntityCreator.createJoyStick(
+            self.joystick1 = joystick1.id
+            let joystick2 = TankGameEntityCreator.createJoyStick(
                 center: CGPoint(x: screenWidth * 5 / 12, y: screenHeight * 7 / 8),
                 tankId: 2,
                 in: ecs,
                 eventContext: events,
                 zPosition: 999)
-            TankGameEntityCreator.createJoyStick(
+            self.joystick2 = joystick2.id
+            let joystick3 = TankGameEntityCreator.createJoyStick(
                 center: CGPoint(x: screenWidth * 9 / 12, y: screenHeight * 7 / 8),
                 tankId: 3,
                 in: ecs,
                 eventContext: events,
                 zPosition: 999)
+            self.joystick3 = joystick3.id
+            self.camera1 = tank1
+            self.camera2 = tank2
+            self.camera3 = tank3
         }
         .on(TankMoveEvent.self) { event, context in
             self.handleTankMove(event, in: context)
+        }
+        .on(ScreenResizeEvent.self) { event, context in
+            self.handleScreenResize(event, in: context)
         }
     }
 
@@ -157,5 +173,56 @@ class TankRaceGame {
                              TankGamePhysicsCategory.water)
         ])
         return tankEntity
+    }
+    private func handleScreenResize(_ event: ScreenResizeEvent, in context: ArkActionContext<NoSound>) {
+        let eventData = event.eventData
+        let screenSize = eventData.newSize
+        let ecs = context.ecs
+
+        let screenWidth = screenSize.width
+        let screenHeight = screenSize.height
+
+        if let joystick1 = joystick1,
+           let joystick1Entity = ecs.getEntity(id: joystick1) {
+            let positionComponent = PositionComponent(
+                position: CGPoint(x: screenWidth * 1 / 12, y: screenHeight * 7 / 8))
+            ecs.upsertComponent(positionComponent, to: joystick1Entity)
+        }
+
+        if let joystick2 = joystick2,
+           let joystick2Entity = ecs.getEntity(id: joystick2) {
+            let positionComponent = PositionComponent(
+                position: CGPoint(x: screenWidth * 5 / 12, y: screenHeight * 7 / 8))
+            ecs.upsertComponent(positionComponent, to: joystick2Entity)
+        }
+
+        if let joystick3 = joystick3,
+           let joystick3Entity = ecs.getEntity(id: joystick3) {
+            let positionComponent = PositionComponent(
+                position: CGPoint(x: screenWidth * 9 / 12, y: screenHeight * 7 / 8))
+            ecs.upsertComponent(positionComponent, to: joystick3Entity)
+        }
+
+        adjustCameraOnResize(camera1, screenSize: screenSize, ecs: ecs, index: 1)
+        adjustCameraOnResize(camera2, screenSize: screenSize, ecs: ecs, index: 2)
+        adjustCameraOnResize(camera3, screenSize: screenSize, ecs: ecs, index: 3)
+    }
+
+    private func adjustCameraOnResize(_ camera: Entity?, screenSize: CGSize, ecs: ArkECSContext, index: Int) {
+        let id = CGFloat(index)
+        let screenWidth = screenSize.width
+        let screenHeight = screenSize.height
+        let screenWidthIncrement = screenWidth / 3 / 2
+
+        if let cam = camera {
+            if let placedCameraComponent = ecs.getComponent(ofType: PlacedCameraComponent.self, for: cam) {
+                let updatedPlacedCameraComponent = PlacedCameraComponent(
+                    camera: placedCameraComponent.camera,
+                    screenPosition: CGPoint(x: id * (screenWidth / 3) - screenWidthIncrement, y: screenHeight / 2),
+                    size: CGSize(width: screenWidth / 3, height: screenHeight)
+                )
+                ecs.upsertComponent(updatedPlacedCameraComponent, to: cam)
+            }
+        }
     }
 }

--- a/ArkKit/ark-camera-kit/CameraContext.swift
+++ b/ArkKit/ark-camera-kit/CameraContext.swift
@@ -48,13 +48,6 @@ class ArkCameraContext: CameraContext {
         return transformedCanvas
     }
 
-    func updateDisplay(_ newDisplaySize: CGSize) {
-        self.displayContext = ArkDisplayContext(
-            canvasSize: displayContext.canvasSize,
-            screenSize: newDisplaySize
-        )
-    }
-
     private func collectCanvasToContainerAndTranslate(
         _ cameraCanva: any Canvas,
         placedCamera: PlacedCameraComponent

--- a/ArkKit/ark-camera-kit/CameraContext.swift
+++ b/ArkKit/ark-camera-kit/CameraContext.swift
@@ -9,7 +9,7 @@ protocol CameraContext {
 
 class ArkCameraContext: CameraContext {
     private let ecs: ArkECSContext
-    let displayContext: DisplayContext
+    private(set) var displayContext: DisplayContext
 
     var cameraEntities: [Entity] {
         ecs.getEntities(with: [PlacedCameraComponent.self])
@@ -46,6 +46,13 @@ class ArkCameraContext: CameraContext {
             )
         }
         return transformedCanvas
+    }
+
+    func updateDisplay(_ newDisplaySize: CGSize) {
+        self.displayContext = ArkDisplayContext(
+            canvasSize: displayContext.canvasSize,
+            screenSize: newDisplaySize
+        )
     }
 
     private func collectCanvasToContainerAndTranslate(

--- a/ArkKit/ark-game/coordinator/ArkGameCoordinator.swift
+++ b/ArkKit/ark-game/coordinator/ArkGameCoordinator.swift
@@ -50,5 +50,15 @@ class ArkGameCoordinator<View> {
 
         // inject renderer dependency into arkView
         arkView.renderableBuilder = canvasRenderer
+
+        // set up listener for cameraContext to resize events
+        arkState.eventManager.subscribe(to: ScreenResizeEvent.self) { event in
+            guard let resizeEvent = event as? ScreenResizeEvent else {
+                return
+            }
+            let eventData = resizeEvent.eventData
+            let screenSize = eventData.newSize
+            cameraContext.updateDisplay(screenSize)
+        }
     }
 }

--- a/ArkKit/ark-game/coordinator/ArkGameCoordinator.swift
+++ b/ArkKit/ark-game/coordinator/ArkGameCoordinator.swift
@@ -50,15 +50,5 @@ class ArkGameCoordinator<View> {
 
         // inject renderer dependency into arkView
         arkView.renderableBuilder = canvasRenderer
-
-        // set up listener for cameraContext to resize events
-        arkState.eventManager.subscribe(to: ScreenResizeEvent.self) { event in
-            guard let resizeEvent = event as? ScreenResizeEvent else {
-                return
-            }
-            let eventData = resizeEvent.eventData
-            let screenSize = eventData.newSize
-            cameraContext.updateDisplay(screenSize)
-        }
     }
 }

--- a/ArkKit/ark-render-kit/DisplayContext.swift
+++ b/ArkKit/ark-render-kit/DisplayContext.swift
@@ -3,9 +3,20 @@ import Foundation
 protocol DisplayContext {
     var canvasSize: CGSize { get }
     var screenSize: CGSize { get }
+
+    func updateScreenSize(_ newSize: CGSize)
 }
 
-struct ArkDisplayContext: DisplayContext {
-    var canvasSize: CGSize
-    var screenSize: CGSize
+class ArkDisplayContext: DisplayContext {
+    private(set) var canvasSize: CGSize
+    private(set) var screenSize: CGSize
+
+    init(canvasSize: CGSize, screenSize: CGSize) {
+        self.canvasSize = canvasSize
+        self.screenSize = screenSize
+    }
+
+    func updateScreenSize(_ newSize: CGSize) {
+        self.screenSize = newSize
+    }
 }

--- a/ArkKit/ark-state-kit/ArkSetupContext.swift
+++ b/ArkKit/ark-state-kit/ArkSetupContext.swift
@@ -2,5 +2,5 @@
 struct ArkSetupContext {
     let ecs: ArkECSContext
     let events: ArkEventContext
-    let display: ArkDisplayContext
+    let display: DisplayContext
 }

--- a/ArkKit/ark-state-kit/ArkState.swift
+++ b/ArkKit/ark-state-kit/ArkState.swift
@@ -24,12 +24,12 @@ class ArkState {
         arkECS.cleanUp()
     }
 
-    func setup(_ setupDelegate: ArkStateSetupDelegate, displayContext: ArkDisplayContext) {
+    func setup(_ setupDelegate: ArkStateSetupDelegate, displayContext: DisplayContext) {
         let context = createActionContext(displayContext: displayContext)
         setupDelegate(context)
     }
 
-    private func createActionContext(displayContext: ArkDisplayContext) -> ArkSetupContext {
+    private func createActionContext(displayContext: DisplayContext) -> ArkSetupContext {
         ArkSetupContext(ecs: arkECS, events: eventManager, display: displayContext)
     }
 }


### PR DESCRIPTION
as title. 

## Key Changes
- made `DisplayContext` stateful and own the displaySize. 
- Will do further changes so that we use ratio relative to screenSize instead of absolute value to deal with ScreenResizeEvents, so that ScreenResizeEvents can be hidden from the dev