### PR TITLE
[ark-loop] feat: implement event-based loop lifecycle management

### DIFF
--- a/ArkGameExample/TankRaceGame/TankRaceGame.swift
+++ b/ArkGameExample/TankRaceGame/TankRaceGame.swift
@@ -122,6 +122,12 @@ class TankRaceGame {
         .on(TankMoveEvent.self) { event, context in
             self.handleTankMoveJoystick(event, in: context)
         }
+//        .forEachTick { timeFacade, context in
+//            print("in tick", timeFacade.clockTimeInSecondsGame, timeFacade.deltaTime)
+//            if timeFacade.clockTimeInSecondsGame >= 3 && timeFacade.clockTimeInSecondsGame <= 4 {
+//                context.events.emit(PauseGameLoopEvent(eventData: PauseGameLoopEventData(timeInGame: timeFacade.clockTimeInSecondsGame)))
+//            }
+//        }
     }
 
     private func setupButtons(screenWidth: CGFloat, screenHeight: CGFloat,
@@ -272,27 +278,6 @@ class TankRaceGame {
                 position: CGPoint(x: screenWidth * 9 / 12, y: screenHeight * 10 / 11))
             ecs.upsertComponent(positionComponent, to: button3Entity)
         }
-
-//        if let fireButton1 = fireButton1,
-//           let button1Entity = ecs.getEntity(id: fireButton1) {
-//            let positionComponent = PositionComponent(
-//                position: CGPoint(x: screenWidth * 1 / 12, y: screenHeight * 8  / 9))
-//            ecs.upsertComponent(positionComponent, to: button1Entity)
-//        }
-//
-//        if let moveButton2 = moveButton2,
-//           let button2Entity = ecs.getEntity(id: moveButton2) {
-//            let positionComponent = PositionComponent(
-//                position: CGPoint(x: screenWidth * 5 / 12, y: screenHeight * 8  / 9))
-//            ecs.upsertComponent(positionComponent, to: button2Entity)
-//        }
-//
-//        if let moveButton3 = moveButton3,
-//           let button3Entity = ecs.getEntity(id: moveButton3) {
-//            let positionComponent = PositionComponent(
-//                position: CGPoint(x: screenWidth * 9 / 12, y: screenHeight * 8  / 9))
-//            ecs.upsertComponent(positionComponent, to: button3Entity)
-//        }
 
         adjustCameraOnResize(camera1, screenSize: screenSize, ecs: ecs, index: 1)
         adjustCameraOnResize(camera2, screenSize: screenSize, ecs: ecs, index: 2)

--- a/ArkKit.xcodeproj/project.pbxproj
+++ b/ArkKit.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		022C42792BC9940D003D6924 /* PauseGameLoopEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022C42782BC9940D003D6924 /* PauseGameLoopEvent.swift */; };
+		022C427B2BC9941B003D6924 /* GameLoopEventData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022C427A2BC9941B003D6924 /* GameLoopEventData.swift */; };
+		022C427D2BC9943B003D6924 /* ResumeGameLoopEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022C427C2BC9943B003D6924 /* ResumeGameLoopEvent.swift */; };
+		022C427F2BC9944A003D6924 /* TerminateGameLoopEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022C427E2BC9944A003D6924 /* TerminateGameLoopEvent.swift */; };
 		0230A4812BB7B452001CFDAF /* AbstractButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0230A4802BB7B452001CFDAF /* AbstractButtonStyle.swift */; };
 		0230A4862BB7F300001CFDAF /* ArkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0230A4852BB7F300001CFDAF /* ArkView.swift */; };
 		0230A48C2BB802E0001CFDAF /* ArkViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0230A48B2BB802E0001CFDAF /* ArkViewFactory.swift */; };
@@ -231,6 +235,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		022C42782BC9940D003D6924 /* PauseGameLoopEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PauseGameLoopEvent.swift; sourceTree = "<group>"; };
+		022C427A2BC9941B003D6924 /* GameLoopEventData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameLoopEventData.swift; sourceTree = "<group>"; };
+		022C427C2BC9943B003D6924 /* ResumeGameLoopEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResumeGameLoopEvent.swift; sourceTree = "<group>"; };
+		022C427E2BC9944A003D6924 /* TerminateGameLoopEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminateGameLoopEvent.swift; sourceTree = "<group>"; };
 		0230A4802BB7B452001CFDAF /* AbstractButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbstractButtonStyle.swift; sourceTree = "<group>"; };
 		0230A4852BB7F300001CFDAF /* ArkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArkView.swift; sourceTree = "<group>"; };
 		0230A48B2BB802E0001CFDAF /* ArkViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArkViewFactory.swift; sourceTree = "<group>"; };
@@ -465,6 +473,17 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		022C42772BC993F9003D6924 /* game-loop-events */ = {
+			isa = PBXGroup;
+			children = (
+				022C42782BC9940D003D6924 /* PauseGameLoopEvent.swift */,
+				022C427A2BC9941B003D6924 /* GameLoopEventData.swift */,
+				022C427C2BC9943B003D6924 /* ResumeGameLoopEvent.swift */,
+				022C427E2BC9944A003D6924 /* TerminateGameLoopEvent.swift */,
+			);
+			path = "game-loop-events";
+			sourceTree = "<group>";
+		};
 		0230A47F2BB7B446001CFDAF /* style */ = {
 			isa = PBXGroup;
 			children = (
@@ -798,6 +817,7 @@
 		02D8E94A2BAC99F100BF3A07 /* ark-loop-kit */ = {
 			isa = PBXGroup;
 			children = (
+				022C42772BC993F9003D6924 /* game-loop-events */,
 				02D8E94B2BAC99FC00BF3A07 /* GameLoopable.swift */,
 				02D8E94D2BAC9A0E00BF3A07 /* GameLoop.swift */,
 			);
@@ -1501,10 +1521,12 @@
 				280CD3CE2BA74E4300372C5D /* BaseSKPhysicsScene.swift in Sources */,
 				94D053882BC6C6D2000280C6 /* ArkExternalResources.swift in Sources */,
 				280CD3C42BA7419400372C5D /* ArkPhysicsContactUpdateDelegate.swift in Sources */,
+				022C42792BC9940D003D6924 /* PauseGameLoopEvent.swift in Sources */,
 				AD2B59B22BB94FBE00198E99 /* ArkMultiplayerManager.swift in Sources */,
 				287B00552BC16E6C002F0114 /* TankHPComponent.swift in Sources */,
 				02C3950F2BA611B80075F1CA /* ArkEventContext.swift in Sources */,
 				8FEB217A2BADE60300788E20 /* DisplayContext.swift in Sources */,
+				022C427D2BC9943B003D6924 /* ResumeGameLoopEvent.swift in Sources */,
 				28A032DC2BAD4E8200851BFF /* StopWatchComponent.swift in Sources */,
 				0230A4862BB7F300001CFDAF /* ArkView.swift in Sources */,
 				945F7F932BA8861300933629 /* AbstractTappable.swift in Sources */,
@@ -1517,6 +1539,7 @@
 				9479A3B42BA95E7E00F99013 /* AbstractColor.swift in Sources */,
 				0267BA2A2BBD10060010F729 /* CleanUpSystem.swift in Sources */,
 				280CD3B92BA7391700372C5D /* PhysicsComponent.swift in Sources */,
+				022C427F2BC9944A003D6924 /* TerminateGameLoopEvent.swift in Sources */,
 				02E0E8F62BA283940043E2BA /* UIKitPolygon.swift in Sources */,
 				280CD3DE2BA8045200372C5D /* RotationComponent.swift in Sources */,
 				287B00592BC17131002F0114 /* TankHPModifyEvent.swift in Sources */,
@@ -1524,6 +1547,7 @@
 				8F5573C12BA42614007030C8 /* Renderable.swift in Sources */,
 				8FEB21882BAE752F00788E20 /* ScreenResizeEvent.swift in Sources */,
 				287B005F2BC19F32002F0114 /* TankReviveEvent.swift in Sources */,
+				022C427B2BC9941B003D6924 /* GameLoopEventData.swift in Sources */,
 				AD787A882B9C6D3A003EBBD0 /* EntityManager.swift in Sources */,
 				02C9CC322BBED5C40098E849 /* UIKitCamera.swift in Sources */,
 				2812FCC32BC4395D00A0FE24 /* TankRaceGameCollisionStrategyManager.swift in Sources */,

--- a/ArkKit/Ark.swift
+++ b/ArkKit/Ark.swift
@@ -78,6 +78,31 @@ class Ark<View, ExternalResources: ArkExternalResources>: ArkProtocol {
             }
             self.displayContext.updateScreenSize(resizeEvent.eventData.newSize)
         }
+
+        arkState.eventManager.subscribe(to: PauseGameLoopEvent.self) { [weak self] event in
+            guard let pauseGameLoopEvent = event as? PauseGameLoopEvent,
+                  let self = self else {
+                return
+            }
+            self.gameLoop?.pauseLoop()
+        }
+
+        arkState.eventManager.subscribe(to: ResumeGameLoopEvent.self) { [weak self] event in
+            guard let resumeGameLoopEvent = event as? ResumeGameLoopEvent,
+                  let self = self else {
+                return
+            }
+            self.gameLoop?.resumeLoop()
+
+        }
+
+        arkState.eventManager.subscribe(to: TerminateGameLoopEvent.self) { [weak self] event in
+            guard let terminateGameEvent = event as? TerminateGameLoopEvent,
+                  let self = self else {
+                return
+            }
+            self.gameLoop?.shutDown()
+        }
     }
 
     private func setup(_ rules: [any Rule]) {
@@ -122,7 +147,7 @@ class Ark<View, ExternalResources: ArkExternalResources>: ArkProtocol {
         }
 
         for rule in timeRules {
-            guard let action = rule.action as? any Action<TimeInterval, ExternalResources> else {
+            guard let action = rule.action as? any Action<ArkTimeFacade, ExternalResources> else {
                 continue
             }
             let system = ArkUpdateSystem(action: action, context: self.actionContext)

--- a/ArkKit/ArkBlueprint.swift
+++ b/ArkKit/ArkBlueprint.swift
@@ -68,7 +68,7 @@ struct ArkBlueprint<ExternalResources: ArkExternalResources> {
         return newSelf
     }
 
-    func forEachTick(_ callback: @escaping UpdateActionCallback<ExternalResources>) -> Self {
+    func forEachTick(_ callback: @escaping GameLoopActionCallback<ExternalResources>) -> Self {
         var newSelf = self
         var newRules = rules
 

--- a/ArkKit/ark-loop-kit/GameLoop.swift
+++ b/ArkKit/ark-loop-kit/GameLoop.swift
@@ -5,6 +5,8 @@ protocol GameLoop {
     func update()
     func getDeltaTime() -> Double
     func shutDown()
+    func pauseLoop()
+    func resumeLoop()
 }
 
 protocol ArkGameWorldUpdateLoopDelegate: AnyObject {

--- a/ArkKit/ark-loop-kit/game-loop-events/GameLoopEventData.swift
+++ b/ArkKit/ark-loop-kit/game-loop-events/GameLoopEventData.swift
@@ -1,8 +1,3 @@
-//
-//  GameLoopEventData.swift
-//  ArkKit
-//
-//  Created by Didymus Ne on 13/4/24.
-//
-
-import Foundation
+protocol GameLoopEventData: ArkEventData {
+    var timeInGame: Double { get }
+}

--- a/ArkKit/ark-loop-kit/game-loop-events/GameLoopEventData.swift
+++ b/ArkKit/ark-loop-kit/game-loop-events/GameLoopEventData.swift
@@ -1,0 +1,8 @@
+//
+//  GameLoopEventData.swift
+//  ArkKit
+//
+//  Created by Didymus Ne on 13/4/24.
+//
+
+import Foundation

--- a/ArkKit/ark-loop-kit/game-loop-events/PauseGameLoopEvent.swift
+++ b/ArkKit/ark-loop-kit/game-loop-events/PauseGameLoopEvent.swift
@@ -1,0 +1,8 @@
+//
+//  PauseGameLoopEvent.swift
+//  ArkKit
+//
+//  Created by Didymus Ne on 13/4/24.
+//
+
+import Foundation

--- a/ArkKit/ark-loop-kit/game-loop-events/PauseGameLoopEvent.swift
+++ b/ArkKit/ark-loop-kit/game-loop-events/PauseGameLoopEvent.swift
@@ -1,8 +1,8 @@
-//
-//  PauseGameLoopEvent.swift
-//  ArkKit
-//
-//  Created by Didymus Ne on 13/4/24.
-//
-
-import Foundation
+struct PauseGameLoopEventData: GameLoopEventData {
+    let timeInGame: Double
+    var name: String = "PauseGame"
+}
+struct PauseGameLoopEvent: ArkEvent {
+    var eventData: PauseGameLoopEventData
+    var priority: Int?
+}

--- a/ArkKit/ark-loop-kit/game-loop-events/ResumeGameLoopEvent.swift
+++ b/ArkKit/ark-loop-kit/game-loop-events/ResumeGameLoopEvent.swift
@@ -1,0 +1,8 @@
+//
+//  ResumeGameLoopEvent.swift
+//  ArkKit
+//
+//  Created by Didymus Ne on 13/4/24.
+//
+
+import Foundation

--- a/ArkKit/ark-loop-kit/game-loop-events/ResumeGameLoopEvent.swift
+++ b/ArkKit/ark-loop-kit/game-loop-events/ResumeGameLoopEvent.swift
@@ -1,8 +1,8 @@
-//
-//  ResumeGameLoopEvent.swift
-//  ArkKit
-//
-//  Created by Didymus Ne on 13/4/24.
-//
-
-import Foundation
+struct ResumeGameLoopEventData: GameLoopEventData {
+    let timeInGame: Double
+    var name: String = "ResumeGame"
+}
+struct ResumeGameLoopEvent: ArkEvent {
+    var eventData: ResumeGameLoopEventData
+    var priority: Int?
+}

--- a/ArkKit/ark-loop-kit/game-loop-events/TerminateGameLoopEvent.swift
+++ b/ArkKit/ark-loop-kit/game-loop-events/TerminateGameLoopEvent.swift
@@ -1,8 +1,8 @@
-//
-//  TerminateGameLoopEvent.swift
-//  ArkKit
-//
-//  Created by Didymus Ne on 13/4/24.
-//
-
-import Foundation
+struct TerminateGameLoopEventData: GameLoopEventData {
+    let timeInGame: Double
+    var name: String = "TerminateGame"
+}
+struct TerminateGameLoopEvent: ArkEvent {
+    var eventData: TerminateGameLoopEventData
+    var priority: Int?
+}

--- a/ArkKit/ark-loop-kit/game-loop-events/TerminateGameLoopEvent.swift
+++ b/ArkKit/ark-loop-kit/game-loop-events/TerminateGameLoopEvent.swift
@@ -1,0 +1,8 @@
+//
+//  TerminateGameLoopEvent.swift
+//  ArkKit
+//
+//  Created by Didymus Ne on 13/4/24.
+//
+
+import Foundation

--- a/ArkKit/ark-physics-kit/ark-physics-facade/AbstractPhysicsArkSimulator.swift
+++ b/ArkKit/ark-physics-kit/ark-physics-facade/AbstractPhysicsArkSimulator.swift
@@ -3,5 +3,7 @@ import Foundation
 protocol AbstractPhysicsArkSimulator: GameLoop {
     var physicsScene: AbstractArkPhysicsScene? { get set }
     func start()
+    func pause()
+    func resume()
     func stop()
 }

--- a/ArkKit/ark-physics-kit/sprite-kit-physics-facade/SKSimulator.swift
+++ b/ArkKit/ark-physics-kit/sprite-kit-physics-facade/SKSimulator.swift
@@ -21,6 +21,18 @@ class SKSimulator: NSObject, AbstractPhysicsArkSimulator {
         view.presentScene(gameScene.basePhysicsScene)
     }
 
+    func pause() {
+        view.isPaused = true
+    }
+
+    func resume() {
+        guard view.scene != nil else {
+            assertionFailure("[SKSimulator.resume] cannot resume without having started")
+            return
+        }
+        view.isPaused = false
+    }
+
     func stop() {
         view.presentScene(nil)
     }
@@ -44,6 +56,14 @@ extension SKSimulator: GameLoop {
 
     func shutDown() {
         self.stop()
+    }
+
+    func pauseLoop() {
+        self.pause()
+    }
+
+    func resumeLoop() {
+        self.resume()
     }
 }
 

--- a/ArkKit/ark-rules-kit/action/Action.swift
+++ b/ArkKit/ark-rules-kit/action/Action.swift
@@ -21,17 +21,15 @@ struct ArkEventAction<Event: ArkEvent, ExternalResources: ArkExternalResources>:
 }
 
 struct ArkTickAction<ExternalResources: ArkExternalResources>: Action {
-    typealias DeltaTime = Double
-
-    let callback: UpdateActionCallback<ExternalResources>
+    let callback: GameLoopActionCallback<ExternalResources>
     let priority: Int
 
-    init(callback: @escaping UpdateActionCallback<ExternalResources>, priority: Int = 0) {
+    init(callback: @escaping GameLoopActionCallback<ExternalResources>, priority: Int = 0) {
         self.callback = callback
         self.priority = priority
     }
 
-    func execute(_ data: DeltaTime,
+    func execute(_ data: ArkTimeFacade,
                  context: ArkActionContext<ExternalResources>) {
         callback(data, context)
     }
@@ -40,5 +38,5 @@ struct ArkTickAction<ExternalResources: ArkExternalResources>: Action {
 typealias ActionCallback<Event: ArkEvent, ExternalResources: ArkExternalResources> =
 (Event, ArkActionContext<ExternalResources>) -> Void
 
-typealias UpdateActionCallback<ExternalResources: ArkExternalResources> =
-(Double, ArkActionContext<ExternalResources>) -> Void
+typealias GameLoopActionCallback<ExternalResources: ArkExternalResources> =
+(ArkTimeFacade, ArkActionContext<ExternalResources>) -> Void

--- a/ArkKit/ark-state-kit/ark-ecs-kit/InternalSystems/ArkUpdateSystem.swift
+++ b/ArkKit/ark-state-kit/ark-ecs-kit/InternalSystems/ArkUpdateSystem.swift
@@ -2,19 +2,34 @@ import Foundation
 
 class ArkUpdateSystem<ExternalResources: ArkExternalResources>: UpdateSystem {
     var active: Bool
-    let action: any Action<TimeInterval, ExternalResources>
+    let action: any Action<ArkTimeFacade, ExternalResources>
     let context: ArkActionContext<ExternalResources>
 
-    init(action: any Action<TimeInterval, ExternalResources>,
+    var stopWatchEntity: Entity?
+
+    init(action: any Action<ArkTimeFacade, ExternalResources>,
          context: ArkActionContext<ExternalResources>,
          active: Bool = true) {
-
         self.active = active
         self.action = action
         self.context = context
+
+        self.stopWatchEntity = context.ecs
+            .getEntities(with: [StopWatchComponent.self])
+            .first
     }
 
     func update(deltaTime: TimeInterval, arkECS: ArkECS) {
-        action.execute(deltaTime, context: context)
+        guard let stopWatchEntity = stopWatchEntity,
+              let stopWatchComponent = arkECS.getComponent(ofType: StopWatchComponent.self, for: stopWatchEntity) else {
+            return
+        }
+        let timeFacade = ArkTimeFacade(deltaTime: deltaTime, clockTimeInSecondsGame: stopWatchComponent.currentTime)
+        action.execute(timeFacade, context: context)
     }
+}
+
+struct ArkTimeFacade {
+    let deltaTime: TimeInterval
+    let clockTimeInSecondsGame: Double
 }


### PR DESCRIPTION
- Add pause, resume, terminate game loop events
- Add default listener to game loop events in `Ark`
- Add time facade for `forEachTick` for better time-based rules

Example:
```swift
blueprint
.forEachTick { timeFacade, context in
    print("in tick", timeFacade.clockTimeInSecondsGame, timeFacade.deltaTime)
    if timeFacade.clockTimeInSecondsGame >= 3 && timeFacade.clockTimeInSecondsGame <= 4 {
        context.events.emit(PauseGameLoopEvent(eventData: PauseGameLoopEventData(timeInGame: timeFacade.clockTimeInSecondsGame)))
    }
}
```