### PR TITLE
[ark-animation]: loop, repeat animations

### DIFF
--- a/ArkGameExample/games/TankGame/ImpactExplosionAnimation.swift
+++ b/ArkGameExample/games/TankGame/ImpactExplosionAnimation.swift
@@ -52,12 +52,13 @@ struct ImpactExplosionAnimation {
                 ecs.upsertComponent(bitmapComponent, to: entity)
             }
             .onComplete { instance in
-                instance.markForDestroyal()
-                ecs.removeEntity(entity)
+                if instance.shouldDestroy {
+                    ecs.removeEntity(entity)
+                }
             }
-        let animationsComponent = ArkAnimationsComponent(animations: [
-            animationInstance
-        ])
+        
+        var animationsComponent = ArkAnimationsComponent()
+        animationsComponent.addAnimation(animationInstance)
         ecs.upsertComponent(animationsComponent, to: entity)
 
         let bitmapComponent = makeBitmapComponent(imageResourcePath: .Sprite_Effects_Explosion_001)

--- a/ArkKit/ark-animation-kit/ArkAnimation.swift
+++ b/ArkKit/ark-animation-kit/ArkAnimation.swift
@@ -8,9 +8,11 @@ struct AnimationKeyframe<T: Equatable>: Equatable {
 
 protocol Animation<T> {
     associatedtype T: Equatable
-
+    
     var keyframes: [AnimationKeyframe<T>] { get }
     var duration: TimeInterval { get }
+    var isLooping: Bool { get }
+    var runCount: Int { get }
 }
 
 /**
@@ -18,11 +20,18 @@ protocol Animation<T> {
  */
 struct ArkAnimation<T>: Animation where T: Equatable {
     private (set) var keyframes: [AnimationKeyframe<T>]
+    private (set) var isLooping: Bool
+    private (set) var runCount: Int
 
     init() {
         self.keyframes = []
+        self.isLooping = false
+        self.runCount = 1
     }
 
+    /**
+     *  The total duration of the animation.
+     */
     var duration: TimeInterval {
         if let lastFrame = keyframes.last {
             return lastFrame.offset + lastFrame.duration
@@ -31,6 +40,9 @@ struct ArkAnimation<T>: Animation where T: Equatable {
         return 0
     }
 
+    /**
+     *  Adds a keyframe to the animation with a given value and duration.
+     */
     func keyframe(_ value: T, duration: Double) -> Self {
         let newOffset: Double = {
             if let previousFrame = keyframes.last {
@@ -42,6 +54,43 @@ struct ArkAnimation<T>: Animation where T: Equatable {
 
         var newSelf = self
         newSelf.keyframes.append(AnimationKeyframe(value: value, offset: newOffset, duration: duration))
+        return newSelf
+    }
+    
+    /**
+     *  Sets the animation to run a given number of times. Should only be called after all keyframes are added.
+     */
+    func `repeat`(times runCount: Int) -> Self {
+        assert(runCount > 0, "Repeat count must be greater than 0")
+        var newSelf = self
+        newSelf.runCount = runCount
+        return newSelf
+    }
+    
+    /**
+     *  Repeats the animation indefinitely.
+     */
+    func loop() -> Self {
+        var newSelf = self
+        newSelf.isLooping = true
+        return newSelf
+    }
+    
+    /**
+     *  Sets whether the animation should loop indefinitely.
+     */
+    func loop(_ value: Bool) -> Self {
+        var newSelf = self
+        newSelf.isLooping = value
+        return newSelf
+    }
+    
+    /**
+     *  Returns a new animation with the keyframes in reverse order.
+     */
+    func reverse() -> Self {
+        var newSelf = self
+        newSelf.keyframes.reverse()
         return newSelf
     }
 }

--- a/ArkKit/ark-animation-kit/ArkAnimationInstance.swift
+++ b/ArkKit/ark-animation-kit/ArkAnimationInstance.swift
@@ -18,9 +18,18 @@ protocol AnimationInstance<T>: AnyObject where T: Equatable {
     var status: AnimationStatus { get }
     var shouldDestroy: Bool { get set }
     var currentFrame: AnimationKeyframe<T> { get }
+    var isPlaying: Bool { get set }
 }
 
 extension AnimationInstance {
+    func play() {
+        isPlaying = true
+    }
+    
+    func pause() {
+        isPlaying = false
+    }
+    
     func stop() {
         shouldDestroy = true
     }
@@ -53,6 +62,7 @@ extension AnimationInstance {
  * Represents a running animation instance as an ArkECS component.
  */
 class ArkAnimationInstance<T>: AnimationInstance where T: Equatable {
+    var isPlaying: Bool
     let animation: ArkAnimation<T>
     var elapsedDelta: TimeInterval
     var updateDelegate: UpdateDelegate<T>?
@@ -76,9 +86,10 @@ class ArkAnimationInstance<T>: AnimationInstance where T: Equatable {
         }) ?? animation.keyframes.last!
     }
 
-    init(animation: ArkAnimation<T>, elapsedDelta: Double = 0) {
+    init(animation: ArkAnimation<T>, elapsedDelta: Double = 0, isPlaying: Bool = true) {
         self.animation = animation
         self.elapsedDelta = elapsedDelta
+        self.isPlaying = isPlaying
         assert(!self.animation.keyframes.isEmpty, "Animation keyframes cannot be empty")
     }
 

--- a/ArkKit/ark-animation-kit/ArkAnimationSystem.swift
+++ b/ArkKit/ark-animation-kit/ArkAnimationSystem.swift
@@ -14,13 +14,18 @@ class ArkAnimationSystem: UpdateSystem {
         let animationComponents = arkECS.getEntities(with: [ArkAnimationsComponent.self])
 
         for entity in animationComponents {
-            guard let animationsComponent = arkECS.getComponent(ofType: ArkAnimationsComponent.self, for: entity) else {
+            guard var animationsComponent = arkECS.getComponent(ofType: ArkAnimationsComponent.self, for: entity) else {
                 return
             }
 
             for animationInstance in animationsComponent.animations {
                 animationInstance.advance(by: deltaTime)
+                if animationInstance.shouldDestroy {
+                    animationsComponent.removeAnimation(animationInstance)
+                }
             }
+            
+            arkECS.upsertComponent(animationsComponent, to: entity)
         }
     }
 }

--- a/ArkKit/ark-animation-kit/ArkAnimationSystem.swift
+++ b/ArkKit/ark-animation-kit/ArkAnimationSystem.swift
@@ -19,6 +19,10 @@ class ArkAnimationSystem: UpdateSystem {
             }
 
             for animationInstance in animationsComponent.animations {
+                if !animationInstance.isPlaying {
+                    continue
+                }
+                
                 animationInstance.advance(by: deltaTime)
                 if animationInstance.shouldDestroy {
                     animationsComponent.removeAnimation(animationInstance)

--- a/ArkKit/ark-animation-kit/ArkAnimationsComponent.swift
+++ b/ArkKit/ark-animation-kit/ArkAnimationsComponent.swift
@@ -1,3 +1,13 @@
 struct ArkAnimationsComponent: Component {
-    var animations: [any AnimationInstance]
+    var animations: [any AnimationInstance] = []
+    
+    @discardableResult mutating func addAnimation(_ animation: any AnimationInstance) -> Self {
+        animations.append(animation)
+        return self
+    }
+    
+    @discardableResult mutating func removeAnimation(_ animation: any AnimationInstance) -> Self {
+        animations.removeAll { $0 === animation }
+        return self
+    }
 }


### PR DESCRIPTION
Adds the following methods to `ArkAnimation`:
- repeat
- loop
- reverse

Non-looped animation instances will be `markForDestroyal` after they have finished playing. This will remove them from the `ArkAnimationsComponent`.

Adds the following methods to `AnimationInstance`:
- pause
- play

```swift
  
/**
 *  Sets the animation to run a given number of times. Should only be called after all keyframes are added.
 */
func `repeat`(times runCount: Int) -> Self 

/**
 *  Repeats the animation indefinitely.
 */
func loop() -> Self

/**
 *  Sets whether the animation should loop indefinitely.
 */
func loop(_ value: Bool) -> Self

func reverse() -> Self
```

Example usage:
```swift
 animation = ArkAnimation()
            .keyframe(.Sprite_Effects_Explosion_001, duration: perFrameDuration)
            .keyframe(.Sprite_Effects_Explosion_002, duration: perFrameDuration)
            .keyframe(.Sprite_Effects_Explosion_003, duration: perFrameDuration)
            .keyframe(.Sprite_Effects_Explosion_004, duration: perFrameDuration)
            .keyframe(.Sprite_Effects_Explosion_005, duration: perFrameDuration)
            .keyframe(.Sprite_Effects_Explosion_006, duration: perFrameDuration)
            .keyframe(.Sprite_Effects_Explosion_007, duration: perFrameDuration)
            .keyframe(.Sprite_Effects_Explosion_008, duration: perFrameDuration)
  		   .repeat(times: 2) // Explode twice
           .loop() // Explode twice, then repeat
           .reverse() // Reverse-explode twice, then repeat
```
