### PR TITLE
[ark-multiplayer] refactor: integrate ark and blueprint with ark network setup

### DIFF
--- a/ArkGameExample/games/TankGame/TankGameManager.swift
+++ b/ArkGameExample/games/TankGame/TankGameManager.swift
@@ -22,6 +22,9 @@ class TankGameManager {
         setUpEntities()
         setUpSystems()
         setUpRules()
+        self.blueprint = self.blueprint.supportNetworkPlay(
+            roomName: "TankFightGame", numberOfPlayers: 2
+        )
     }
 
     func setUpAudio() {
@@ -121,8 +124,6 @@ class TankGameManager {
     }
 
     func setUpRules() {
-//        blueprint = blueprint.setupMultiplayer(serviceName: "tankGame")
-
         blueprint = blueprint
             .on(ScreenResizeEvent.self) { event, context in
                 self.handleScreenResize(event, in: context)

--- a/ArkGameExample/pages/ArkDemoGameHostingPage.swift
+++ b/ArkGameExample/pages/ArkDemoGameHostingPage.swift
@@ -3,29 +3,19 @@ import UIKit
 protocol AbstractDemoGameHostingPage: UIViewController { }
 
 class ArkDemoGameHostingPage<T: ArkExternalResources>: UIViewController {
-    // inject blueprint here
-    var arkBlueprint: ArkBlueprint<T>?
     var ark: Ark<UIView, T>?
     var shouldShowMultiplayerOptions = false
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        guard let blueprint = arkBlueprint else {
-            return
-        }
 
         if shouldShowMultiplayerOptions {
             presentMultiplayerOptions()
         }
+    }
 
-        // Example on how to inject views into ark blueprint after win/ termination
-//        arkBlueprint = arkBlueprint?.on(TerminateGameLoopEvent.self) { event, context in
-//            // add pop-up view here
-//            self.present(<#T##viewControllerToPresent: UIViewController##UIViewController#>, animated: <#T##Bool#>)
-//        }
-
-        // load blueprint
-        ark = Ark(rootView: self, blueprint: blueprint)
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
         ark?.start()
     }
 

--- a/ArkGameExample/pages/ArkDemoMultiplayerPopover.swift
+++ b/ArkGameExample/pages/ArkDemoMultiplayerPopover.swift
@@ -14,13 +14,13 @@ class ArkDemoMultiplayerPopover: UIViewController {
     }
 
     private func setupButtons() {
-        let joinButton = UIButton(type: .system)
-        joinButton.setTitle("Start Multiplayer Game", for: .normal)
-        joinButton.translatesAutoresizingMaskIntoConstraints = false
-
         let startButton = UIButton(type: .system)
-        startButton.setTitle("Join Multiplayer Game", for: .normal)
+        startButton.setTitle("Start Multiplayer Game", for: .normal)
         startButton.translatesAutoresizingMaskIntoConstraints = false
+
+        let joinButton = UIButton(type: .system)
+        joinButton.setTitle("Join Multiplayer Game", for: .normal)
+        joinButton.translatesAutoresizingMaskIntoConstraints = false
 
         view.addSubview(joinButton)
         view.addSubview(startButton)
@@ -29,17 +29,17 @@ class ArkDemoMultiplayerPopover: UIViewController {
         startButton.addTarget(self, action: #selector(startTapped), for: .touchUpInside)
 
         NSLayoutConstraint.activate([
-            joinButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            joinButton.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: -25),
-            joinButton.widthAnchor.constraint(equalToConstant: 200),
-            joinButton.heightAnchor.constraint(equalToConstant: 40)
+            startButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            startButton.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: -25),
+            startButton.widthAnchor.constraint(equalToConstant: 200),
+            startButton.heightAnchor.constraint(equalToConstant: 40)
         ])
 
         NSLayoutConstraint.activate([
-            startButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            startButton.topAnchor.constraint(equalTo: joinButton.bottomAnchor, constant: 20),
-            startButton.widthAnchor.constraint(equalToConstant: 200),
-            startButton.heightAnchor.constraint(equalToConstant: 40)
+            joinButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            joinButton.topAnchor.constraint(equalTo: startButton.bottomAnchor, constant: 20),
+            joinButton.widthAnchor.constraint(equalToConstant: 200),
+            joinButton.heightAnchor.constraint(equalToConstant: 40)
         ])
     }
 

--- a/ArkGameExample/utils/GameHostingPageFactory.swift
+++ b/ArkGameExample/utils/GameHostingPageFactory.swift
@@ -6,19 +6,30 @@ class GameHostingPageFactory {
         switch game {
         case .TankGame:
             let blueprint: ArkBlueprint<TankGameExternalResources> = TankGameManager().blueprint
-
             let vc: ArkDemoGameHostingPage<TankGameExternalResources> = ArkDemoGameHostingPage()
-            vc.arkBlueprint = blueprint
+
+            // inject ark and blueprint dependencies here
+            if role == nil {
+                vc.ark = Ark(rootView: vc, blueprint: blueprint)
+            } else {
+                guard let role = role else {
+                    return vc
+                }
+                var updatedBlueprint = blueprint.setRole(role)
+                vc.ark = Ark(rootView: vc, blueprint: updatedBlueprint)
+            }
             return vc
         case .SnakeChomp:
             let blueprint: ArkBlueprint<SnakeGameExternalResources> = SnakeGame().blueprint
             let vc: ArkDemoGameHostingPage<SnakeGameExternalResources> = ArkDemoGameHostingPage()
-            vc.arkBlueprint = blueprint
+            let ark = Ark(rootView: vc, blueprint: blueprint)
+            vc.ark = ark
             return vc
         case .TankRaceGame:
             let blueprint: ArkBlueprint<TankRaceGameExternalResources> = TankRaceGame().blueprint
             let vc: ArkDemoGameHostingPage<TankRaceGameExternalResources> = ArkDemoGameHostingPage()
-            vc.arkBlueprint = blueprint
+            let ark = Ark(rootView: vc, blueprint: blueprint)
+            vc.ark = ark
             return vc
         }
     }
@@ -46,9 +57,9 @@ class GameHostingPageFactory {
 
     private static func shouldPresentMultiplayerOptions(for game: DemoGames) -> Bool {
         switch game {
-        case .TankGame, .TankRaceGame:
+        case .TankGame:
             return true
-        case .SnakeChomp:
+        case .SnakeChomp, .TankRaceGame:
             return false
         }
     }

--- a/ArkKit/ArkBlueprint.swift
+++ b/ArkKit/ArkBlueprint.swift
@@ -7,6 +7,7 @@ struct ArkBlueprint<ExternalResources: ArkExternalResources> {
     private(set) var rules: [any Rule] = []
     private(set) var setupFunctions: [ArkStateSetupDelegate] = []
     private(set) var soundMapping: [ExternalResources.AudioEnum: any Sound]?
+    private(set) var networkPlayableInfo: ArkNetworkPlayableInfo?
 
     // game world size
     private(set) var frameWidth: Double
@@ -80,23 +81,36 @@ struct ArkBlueprint<ExternalResources: ArkExternalResources> {
         return newSelf
     }
 
-//    func setupMultiplayer(serviceName: String = "Ark") -> Self {
-//        let fn: ArkStateSetupDelegate = { context in
-//            var events = context.events
-//
-//            let multiplayerManager = ArkMultiplayerManager(serviceName: serviceName)
-//            let multiplayerEventManager = ArkMultiplayerEventManager(arkEventManager: events,
-//                                                                     delegate: multiplayerManager)
-//            multiplayerManager.multiplayerEventManager = multiplayerEventManager
-//
-//            events.delegate = multiplayerEventManager
-//        }
-//
-//        var stateSetupFunctionsCopy = setupFunctions
-//        stateSetupFunctionsCopy.insert(fn, at: 0)
-//
-//        var newSelf = self
-//        newSelf.setupFunctions = stateSetupFunctionsCopy
-//        return newSelf
-//    }
+    func supportNetworkPlay(roomName: String, numberOfPlayers: Int) -> Self {
+        var newSelf = self
+        newSelf.networkPlayableInfo = ArkNetworkPlayableInfo(
+            roomName: roomName, numberOfPlayers: numberOfPlayers
+        )
+        return newSelf
+    }
+
+    func setRole(_ role: ArkPeerRole) -> Self {
+        var newSelf = self
+        guard let originalNetworkInfo = self.networkPlayableInfo else {
+            return newSelf
+        }
+        newSelf.networkPlayableInfo = ArkNetworkPlayableInfo(
+            roomName: originalNetworkInfo.roomName,
+            numberOfPlayers: originalNetworkInfo.numberOfPlayers,
+            role: role
+        )
+        return newSelf
+    }
+}
+
+struct ArkNetworkPlayableInfo {
+    let roomName: String
+    let numberOfPlayers: Int
+    let role: ArkPeerRole?
+
+    init(roomName: String, numberOfPlayers: Int, role: ArkPeerRole? = nil) {
+        self.roomName = roomName
+        self.numberOfPlayers = numberOfPlayers
+        self.role = role
+    }
 }

--- a/ArkKit/ark-multiplayer-kit/ArkMultiplayerManager.swift
+++ b/ArkKit/ark-multiplayer-kit/ArkMultiplayerManager.swift
@@ -60,7 +60,6 @@ class ArkMultiplayerManager: ArkNetworkDelegate, ArkMultiplayerContext {
 
     func connectedDevicesChanged(manager: ArkNetworkService, connectedDevices: [String]) {
         peers = connectedDevices
-        updateRoles()
     }
 
     private func updateRoles() {


### PR DESCRIPTION
### Key Changes
- alternative implementation
- adds blueprint and ark integration

- i think we can do away with arkmultiplayerContext since we're not exposing it directly to the dev to `emit` or `sendECS`
- these are all hidden just by if the dev lets the blueprint have `networkPlayableInformation`

### Note
- participant lags on my device -- see if others experience the lag also
- screen components are not sendable? they should be but we should have a local to emit events from participant to host.
- Need to come up with a way to limit players in the room.