### PR TITLE
[ark-ecs-tests] fix: resolve regression bug in test

### DIFF
--- a/ArkKitTests/ark-state-kit-tests/ark-ecs-kit-tests/ArkECSTests.swift
+++ b/ArkKitTests/ark-state-kit-tests/ark-ecs-kit-tests/ArkECSTests.swift
@@ -57,7 +57,7 @@ final class ArkECSTests: XCTestCase {
         XCTAssertNotNil(retrievedEntity, "Should retrieve the entity with the given ID.")
         XCTAssertEqual(retrievedEntity?.id, newEntity.id, "Retrieved entity should have the same ID as the new entity.")
 
-        let nonExistentEntity = arkECS.getEntity(id: UUID())
+        let nonExistentEntity = arkECS.getEntity(id: newEntity.id + 1)
         XCTAssertNil(nonExistentEntity, "Should return nil for a non-existent entity ID.")
     }
 


### PR DESCRIPTION
- quick fix on a failing test case due to change in entityId definition