### PR TITLE
[ark-multiplayer] fix: use dummy ecs and set up rules and functions for audio to play in participant

### DIFF
--- a/ArkKit/app/Ark.swift
+++ b/ArkKit/app/Ark.swift
@@ -27,6 +27,10 @@ class Ark<View, ExternalResources: ArkExternalResources>: ArkProtocol {
                          audio: audioContext)
     }
 
+    var setupContext: ArkSetupContext {
+        ArkSetupContext(ecs: arkState.arkECS, events: arkState.eventManager, display: displayContext)
+    }
+
     var canvasRenderableBuilder: (any RenderableBuilder<View>)?
 
     // network dependencies

--- a/ArkKit/app/utils/set-up/ArkSetUpIfHostStrategy.swift
+++ b/ArkKit/app/utils/set-up/ArkSetUpIfHostStrategy.swift
@@ -25,9 +25,9 @@ extension ArkSetUpIfHostStrategy: ArkPlayerStateSetupDelegate {
     func setup(_ playerId: Int) {
         let playerSetUpCallbacks = ark?.blueprint.playerSpecificSetupFunctions
         guard let specificPlayerSetUp = playerSetUpCallbacks?[playerId],
-              let displayContext = ark?.displayContext else {
+              let ark = ark else {
             return
         }
-        ark?.arkState.setup(specificPlayerSetUp, displayContext: displayContext)
+        ark.arkState.setup(specificPlayerSetUp, with: ark.setupContext)
     }
 }

--- a/ArkKit/app/utils/set-up/ArkSetUpStrategy.swift
+++ b/ArkKit/app/utils/set-up/ArkSetUpStrategy.swift
@@ -46,7 +46,7 @@ extension ArkSetUpStrategy {
         }
     }
 
-    func setup(_ rules: [any Rule]) {
+    func setup(_ rules: [any Rule], with actionContext: ArkActionContext<ExternalResources>? = nil) {
         guard let ark = ark else {
             return
         }
@@ -73,7 +73,7 @@ extension ArkSetUpStrategy {
                 let areConditionsSatisfied = rule.conditions
                     .allSatisfy { $0(ark.actionContext.ecs) }
                 if areConditionsSatisfied {
-                    event.executeAction(rule.action, context: ark.actionContext)
+                    event.executeAction(rule.action, context: actionContext ?? ark.actionContext)
                 }
             }
         }
@@ -100,13 +100,13 @@ extension ArkSetUpStrategy {
         }
     }
 
-    func setup(_ stateSetupFunctions: [ArkStateSetupDelegate]) {
+    func setup(_ stateSetupFunctions: [ArkStateSetupDelegate], with setUpContext: ArkSetupContext? = nil) {
         guard let ark = ark else {
             return
         }
 
         for stateSetupFunction in stateSetupFunctions {
-            ark.arkState.setup(stateSetupFunction, displayContext: ark.displayContext)
+            ark.arkState.setup(stateSetupFunction, with: setUpContext ?? ark.setupContext)
         }
     }
 

--- a/ArkKit/ark-state-kit/ArkState.swift
+++ b/ArkKit/ark-state-kit/ArkState.swift
@@ -24,8 +24,9 @@ class ArkState {
         arkECS.cleanUp()
     }
 
-    func setup(_ setupDelegate: ArkStateSetupDelegate, displayContext: DisplayContext) {
-        let context = createActionContext(displayContext: displayContext)
+    func setup(_ setupDelegate: ArkStateSetupDelegate,
+               with setUpContext: ArkSetupContext) {
+        let context = setUpContext
         setupDelegate(context)
     }
 


### PR DESCRIPTION
- Use a dummy ECS in the subscription for events in participant set-up so that the participant's main ECS state is read from the host's broadcasted/published ECS